### PR TITLE
feat(rag): rag-day-07 parent/child structural chunker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 ## [Unreleased]
 
-_Nothing yet. Work begins on rag-day-07 (parent/child structural chunker)._
+### Added
+- **rag-day-07:** Parent/child structural chunker in `src/processing/chunker.py`. Pure, dependency-free: produces parents (target 1536 / max 2048 tokens, broken at paragraph boundaries) and children (target 384 / max 512, broken at segment boundaries). `TokenCounter` injected via DI for future BGE-M3 tokenizer swap. SuttaCentral loader rewired to emit parent+child instead of flat per-segment rows. `scripts/rechunk.py` rebuilds existing Instances in-place (ran on live DB: 124,532 flat → 10,227 structured chunks = 3,749 parents + 6,478 children, 48 s, 0 orphan children). 18 unit + 1 rechunk-idempotency integration test added (79 total passing).
 
 ---
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -36,7 +36,7 @@
 | rag-day-04 | Full ingest SuttaCentral (Sujato EN для MN/DN/SN/AN) | ✅ Done | `8ef9519` |
 | rag-day-05 | **Gate:** Golden v0.1 от буддолога (30 QA) | 🚧 Blocked | Нужен буддолог на связи |
 | rag-day-06 | Cleaner: Unicode NFC, Pali диакритика (IAST + ASCII-fold) | ✅ Done | `ce186c5` |
-| rag-day-07 | Структурный chunker (384 child / 1024-2048 parent) | 📋 Planned | — |
+| rag-day-07 | Структурный chunker (384 child / 1024-2048 parent) | ✅ Done | `6c8ff98` |
 | … | (всего 120 дней в плане) | | |
 
 ### App-трек

--- a/scripts/rechunk.py
+++ b/scripts/rechunk.py
@@ -1,0 +1,181 @@
+"""Rebuild chunks per Instance using the parent/child structural chunker.
+
+The rag-day-04 loader created one flat Chunk per bilara segment.
+rag-day-06 backfilled canonical text + ASCII fold on those rows. Now
+rag-day-07 replaces that flat layout with parent/child: each Instance
+drops its chunks and re-emits the structured version produced by
+``src.processing.chunker``.
+
+Why a separate script instead of rerunning the ingest:
+* The ingest loader short-circuits on ``content_hash`` match — re-running
+  it is a no-op (exactly what we want for normal use). Rechunking is a
+  deliberate schema-migration-like event, so it gets its own entry point.
+* It lets us stream per-Instance, commit between each, and recover from
+  a crash without losing the whole batch.
+
+Idempotent: if the rows under an Instance already look like parent/child
+(i.e. contain at least one row with ``is_parent=True``), skip the
+Instance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+import sqlalchemy as sa  # noqa: E402
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine  # noqa: E402
+
+from src.config import get_settings  # noqa: E402
+from src.db.models.frbr import Chunk, Instance  # noqa: E402
+from src.processing.chunker import SegmentInput, chunk_segments  # noqa: E402
+from src.processing.cleaner import to_ascii_fold  # noqa: E402
+
+
+async def _rechunk_one_instance(session, instance_id) -> tuple[int, int, int]:
+    """Replace flat chunks for a single Instance with parent/child.
+
+    Returns (deleted_count, inserted_count, was_already_structured).
+    """
+    # Fast-path: if any chunk is already a parent, assume the Instance
+    # is up to date and skip. Cheaper than comparing full structure.
+    already = (
+        await session.execute(
+            sa.select(sa.func.count())
+            .select_from(Chunk)
+            .where(Chunk.instance_id == instance_id, Chunk.is_parent.is_(True))
+        )
+    ).scalar_one()
+    if already:
+        return (0, 0, 1)
+
+    # Load existing flat chunks in sequence order; they already carry
+    # canonical (NFC + IAST) text from the day-6 cleaner pass.
+    rows = (
+        await session.execute(
+            sa.select(Chunk.segment_id, Chunk.text)
+            .where(Chunk.instance_id == instance_id)
+            .order_by(Chunk.sequence)
+        )
+    ).all()
+    if not rows:
+        return (0, 0, 0)
+
+    # Drop rows with missing segment_id or empty text; pre-day-6 data
+    # always populated both, but staying defensive means rechunk never
+    # pollutes ``metadata_json.segment_ids`` with empty strings.
+    segments = [
+        SegmentInput(segment_id=seg_id, text=text) for seg_id, text in rows if seg_id and text
+    ]
+    parents = chunk_segments(segments)
+
+    # Delete old flat rows. ``parent_chunk_id`` FK is SET NULL so order
+    # does not matter here, but staying tidy is nice.
+    deleted = (
+        await session.execute(sa.delete(Chunk).where(Chunk.instance_id == instance_id))
+    ).rowcount or 0
+
+    inserted = 0
+    sequence = 0
+    for parent in parents:
+        parent_row = Chunk(
+            instance_id=instance_id,
+            sequence=sequence,
+            text=parent.text,
+            text_ascii_fold=to_ascii_fold(parent.text),
+            token_count=parent.token_count,
+            is_parent=True,
+            segment_id=parent.segment_ids[0] if parent.segment_ids else None,
+            metadata_json={
+                "stage": "parent",
+                "segment_ids": parent.segment_ids,
+                "position": parent.position,
+                "child_count": len(parent.children),
+            },
+        )
+        session.add(parent_row)
+        await session.flush()
+        inserted += 1
+        sequence += 1
+
+        for child in parent.children:
+            session.add(
+                Chunk(
+                    instance_id=instance_id,
+                    parent_chunk_id=parent_row.id,
+                    sequence=sequence,
+                    text=child.text,
+                    text_ascii_fold=to_ascii_fold(child.text),
+                    token_count=child.token_count,
+                    is_parent=False,
+                    segment_id=child.segment_ids[0] if child.segment_ids else None,
+                    metadata_json={
+                        "stage": "child",
+                        "segment_ids": child.segment_ids,
+                        "position_in_parent": child.position_in_parent,
+                    },
+                )
+            )
+            inserted += 1
+            sequence += 1
+    await session.flush()
+    return (deleted, inserted, 0)
+
+
+async def _run() -> int:
+    settings = get_settings()
+    engine = create_async_engine(settings.database_url, future=True, echo=False)
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    totals = {"instances": 0, "skipped": 0, "deleted": 0, "inserted": 0}
+    try:
+        async with session_maker() as session:
+            start = time.monotonic()
+            instance_ids = (
+                (await session.execute(sa.select(Instance.id).order_by(Instance.id)))
+                .scalars()
+                .all()
+            )
+            total = len(instance_ids)
+            for idx, inst_id in enumerate(instance_ids, 1):
+                deleted, inserted, skipped = await _rechunk_one_instance(session, inst_id)
+                totals["instances"] += 1
+                totals["deleted"] += deleted
+                totals["inserted"] += inserted
+                totals["skipped"] += skipped
+                await session.commit()
+                if idx % 200 == 0 or idx == total:
+                    print(
+                        f"  ... {idx}/{total} instances — "
+                        f"deleted {totals['deleted']:,}, inserted {totals['inserted']:,}"
+                    )
+        elapsed = time.monotonic() - start
+    finally:
+        await engine.dispose()
+
+    print(
+        "\n=== Rechunk summary ===\n"
+        f"  instances scanned:  {totals['instances']:>7,}\n"
+        f"  instances skipped:  {totals['skipped']:>7,} (already parent/child)\n"
+        f"  chunks deleted:     {totals['deleted']:>7,}\n"
+        f"  chunks inserted:    {totals['inserted']:>7,}\n"
+        f"  elapsed:            {elapsed:>7.1f}s"
+    )
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ingest/suttacentral/loader.py
+++ b/src/ingest/suttacentral/loader.py
@@ -35,6 +35,7 @@ from src.db.models.frbr import Chunk, Expression, Instance, Work
 from src.db.models.lookups import Author, Language
 from src.ingest.suttacentral.models import BilaraFile, FileKind, Segment
 from src.ingest.suttacentral.parser import iter_bilara_files, iter_segments
+from src.processing.chunker import SegmentInput, chunk_segments
 from src.processing.cleaner import to_ascii_fold, to_canonical
 
 # SuttaCentral's bilara-data is released under CC0-1.0. The license is
@@ -205,27 +206,72 @@ async def load_file(
     session.add(instance)
     await session.flush()  # populate instance.id for FK on chunks
 
-    chunks_inserted = 0
-    for seq, seg in enumerate(segments):
+    # Step 1: clean every segment to its canonical form. Drop segments
+    # that collapse to empty after cleaning — they add no retrieval
+    # signal and would confuse the chunker's token budget.
+    cleaned_segments: list[SegmentInput] = []
+    for seg in segments:
         canonical = to_canonical(seg.text)
         if not canonical:
-            # A segment that reduces to empty after cleaning (rare, but
-            # bilara occasionally ships whitespace-only keys) is not
-            # worth an index row.
             continue
-        session.add(
-            Chunk(
-                instance_id=instance.id,
-                sequence=seq,
-                text=canonical,
-                text_ascii_fold=to_ascii_fold(canonical),
-                token_count=max(1, len(canonical.split())),
-                is_parent=False,
-                segment_id=seg.segment_id,
-                metadata_json={"stage": "bilara-clean"},
-            )
+        cleaned_segments.append(SegmentInput(segment_id=seg.segment_id, text=canonical))
+
+    # Step 2: run the structural chunker. The chunker is pure — its
+    # output is the source-of-truth for how this sutta should look in
+    # the index, regardless of historical ingest state.
+    parents = chunk_segments(cleaned_segments)
+
+    # Step 3: persist parents first (so children have a PK to FK to),
+    # then children. Sequence numbers are contiguous across the full
+    # Instance: parent_0, its children, parent_1, its children, ...
+    # This keeps ``(instance_id, sequence)`` a meaningful ordering for
+    # both kinds of chunk without needing a separate numeric space.
+    chunks_inserted = 0
+    next_sequence = 0
+    for parent in parents:
+        parent_row = Chunk(
+            instance_id=instance.id,
+            sequence=next_sequence,
+            text=parent.text,
+            text_ascii_fold=to_ascii_fold(parent.text),
+            token_count=parent.token_count,
+            is_parent=True,
+            # Parents aggregate many bilara segments — record the first
+            # one as ``segment_id`` for quick citation, and the full list
+            # lives in ``metadata_json`` for precise provenance.
+            segment_id=parent.segment_ids[0] if parent.segment_ids else None,
+            metadata_json={
+                "stage": "parent",
+                "segment_ids": parent.segment_ids,
+                "position": parent.position,
+                "child_count": len(parent.children),
+            },
         )
+        session.add(parent_row)
+        await session.flush()  # populate parent_row.id for the children FK
         chunks_inserted += 1
+        next_sequence += 1
+
+        for child in parent.children:
+            session.add(
+                Chunk(
+                    instance_id=instance.id,
+                    parent_chunk_id=parent_row.id,
+                    sequence=next_sequence,
+                    text=child.text,
+                    text_ascii_fold=to_ascii_fold(child.text),
+                    token_count=child.token_count,
+                    is_parent=False,
+                    segment_id=child.segment_ids[0] if child.segment_ids else None,
+                    metadata_json={
+                        "stage": "child",
+                        "segment_ids": child.segment_ids,
+                        "position_in_parent": child.position_in_parent,
+                    },
+                )
+            )
+            chunks_inserted += 1
+            next_sequence += 1
     await session.flush()
 
     return LoadResult(

--- a/src/processing/chunker.py
+++ b/src/processing/chunker.py
@@ -1,0 +1,326 @@
+"""Parent-child structural chunker for Dharma-RAG.
+
+Design note — why this module exists
+------------------------------------
+Bilara ships segments (~10-30 tokens each). Neither of our downstream
+consumers can use segments directly:
+
+* **Retrieval indexes** (BGE-M3 dense, sparse, BM25) want chunks of
+  roughly 256-512 tokens — one thought at a time, so the embedding
+  captures a single idea cleanly.
+* **LLM context** wants 1024-2048 tokens of cohesive prose so the
+  generation model actually understands the passage.
+
+A single chunk size can't serve both. The industry pattern
+(LangChain's Parent Document Retrieval, Anthropic's Contextual
+Retrieval paper) is to store **two** sizes per text: small child
+chunks drive the search, and their parent is what the LLM sees.
+This module produces both, from an ordered sequence of bilara
+segments.
+
+Design principles
+-----------------
+1. **Pure and dependency-free.** No DB, no tokenizer library. The
+   token counter is injected so we can start with a heuristic and
+   swap in the BGE-M3 tokenizer on rag-day-10 without touching this
+   file.
+2. **Structure-aware breaks.** Bilara segment IDs encode paragraph
+   structure (``mn1:3.2`` → paragraph 3, sentence 2). We prefer to
+   start new parents at paragraph boundaries and new children at
+   sentence boundaries, falling back to hard-splits only when a
+   single segment exceeds the target.
+3. **Deterministic.** Same input → same chunks, every time. That's
+   what makes ingest idempotent and lets us compare eval runs
+   across days.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Final
+
+# Type alias: any function that turns text into a token count.
+# Default is a word-count heuristic (good enough for layout); swap in
+# a real tokenizer on rag-day-10.
+TokenCounter = Callable[[str], int]
+
+# --- Default target sizes (override per call when experimenting) ----------
+
+TARGET_PARENT_TOKENS: Final[int] = 1536
+MAX_PARENT_TOKENS: Final[int] = 2048
+TARGET_CHILD_TOKENS: Final[int] = 384
+MAX_CHILD_TOKENS: Final[int] = 512
+
+# Bilara segment IDs look like ``uid:paragraph.sentence`` (or
+# ``uid:paragraph.sentence.word`` for fine-grained cases). Capturing
+# the paragraph number lets us detect "new paragraph starts here"
+# cheaply. Range-form uids (``an1.1-10``) complicate the colon split,
+# so we anchor on the last colon.
+_PARAGRAPH_RE: Final[re.Pattern[str]] = re.compile(r"^[^:]+:(\d+)\.")
+
+
+# ---------------------------------------------------------------------------
+# Inputs / outputs
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SegmentInput:
+    """A single bilara-level segment fed to the chunker.
+
+    The chunker takes segments (not raw text) because segment IDs carry
+    structural information we want to exploit (paragraph breaks) and
+    preserve in the output metadata (``segment_ids`` per chunk for
+    citations).
+
+    Invariant: ``text`` must already be Unicode-NFC-normalised — the
+    chunker is the point where per-segment cleaning results feed into
+    persistent state, and downstream code (ASCII fold, BM25 index,
+    embedding) assumes NFC. We assert rather than silently re-normalise
+    so a missing ``to_canonical`` call in an upstream pipeline surfaces
+    loudly in tests.
+    """
+
+    segment_id: str
+    text: str
+
+    def __post_init__(self) -> None:
+        if self.text and not unicodedata.is_normalized("NFC", self.text):
+            raise ValueError(
+                f"SegmentInput.text must be NFC-normalised; got a "
+                f"denormalised string for segment_id={self.segment_id!r}. "
+                "Pipe the text through src.processing.cleaner.to_canonical "
+                "before constructing a SegmentInput."
+            )
+
+
+@dataclass(slots=True)
+class ChildChunk:
+    """A small chunk that goes into the retrieval indexes.
+
+    ``segment_ids`` is the list of bilara segments concatenated to
+    form this child, in order. ``position_in_parent`` is 0-based within
+    its parent, used for stable ordering on retrieval-time reassembly.
+    """
+
+    text: str
+    token_count: int
+    segment_ids: list[str]
+    position_in_parent: int
+
+
+@dataclass(slots=True)
+class ParentChunk:
+    """A large chunk containing one or more children.
+
+    ``position`` is 0-based within the full Instance (i.e. per sutta).
+    ``children`` are ordered by ``position_in_parent``.
+    """
+
+    text: str
+    token_count: int
+    segment_ids: list[str]
+    position: int
+    children: list[ChildChunk] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def default_token_count(text: str) -> int:
+    """Quick-and-dirty token estimate.
+
+    Why this heuristic: English words map to about 1.3 tokens in most
+    modern tokenisers (tiktoken, BPE-based ones). Pali transliteration
+    with diacritics tokenises finer (2-3 tokens per unfamiliar word),
+    but since ingested text is mostly English translations plus a few
+    Pali quotes, the 1.3 factor is close enough for layout decisions.
+
+    A real tokenizer call costs ~100 µs per segment; this heuristic
+    costs ~1 µs. Over 124k segments that's a 20-second difference.
+    Good enough for rag-day-07; swap for the BGE-M3 tokenizer on
+    rag-day-10 when accuracy actually matters.
+    """
+    words = len(text.split())
+    return max(1, int(round(words * 1.3)))
+
+
+def chunk_segments(
+    segments: Sequence[SegmentInput],
+    *,
+    target_parent_tokens: int = TARGET_PARENT_TOKENS,
+    max_parent_tokens: int = MAX_PARENT_TOKENS,
+    target_child_tokens: int = TARGET_CHILD_TOKENS,
+    max_child_tokens: int = MAX_CHILD_TOKENS,
+    count_tokens: TokenCounter = default_token_count,
+) -> list[ParentChunk]:
+    """Turn an ordered list of segments into parent+child chunks.
+
+    Algorithm, in plain English:
+
+    1. Walk segments left to right, accumulating into the current
+       parent buffer.
+    2. When the buffer reaches ``target_parent_tokens`` AND the next
+       segment starts a new paragraph (different number after the
+       colon), close the parent — this gives us a natural boundary
+       break.
+    3. If the buffer ever exceeds ``max_parent_tokens``, force-close
+       even mid-paragraph (safety valve).
+    4. Within each closed parent, sub-walk its segments to build
+       children with the same ``target``/``max`` logic at sentence
+       (segment) boundaries.
+
+    Target vs max: the target is the "we'd like to close around here"
+    threshold; max is the "never exceed this" safety rail. Keeping the
+    gap (1536 → 2048, 384 → 512) lets us wait for a natural break
+    instead of chopping mid-thought.
+
+    Returns a list of ``ParentChunk`` objects in source order. Each
+    parent carries its children, already sliced and numbered. Empty
+    input → empty output (no error).
+    """
+    if not segments:
+        return []
+
+    # Pre-compute paragraph keys so we don't re-regex the same segment
+    # multiple times when checking boundaries.
+    paragraphs = [_paragraph_of(s.segment_id) for s in segments]
+    token_counts = [count_tokens(s.text) for s in segments]
+
+    # First pass: group into parents.
+    parents: list[list[int]] = []  # each element is a list of segment indices
+    current: list[int] = []
+    current_tokens = 0
+
+    for i in range(len(segments)):
+        seg_tokens = token_counts[i]
+
+        # At a parent boundary if (a) current is already at or past
+        # target AND this segment starts a new paragraph, or (b) adding
+        # this segment would exceed max (safety valve).
+        at_paragraph_break = (
+            i > 0 and paragraphs[i] is not None and paragraphs[i] != paragraphs[i - 1]
+        )
+        would_overflow = current_tokens + seg_tokens > max_parent_tokens
+
+        if current and (
+            (current_tokens >= target_parent_tokens and at_paragraph_break) or would_overflow
+        ):
+            parents.append(current)
+            current = []
+            current_tokens = 0
+
+        current.append(i)
+        current_tokens += seg_tokens
+
+    if current:
+        parents.append(current)
+
+    # Second pass: slice each parent into children.
+    result: list[ParentChunk] = []
+    for parent_idx, seg_indices in enumerate(parents):
+        parent_segments = [segments[i] for i in seg_indices]
+        parent_token_counts = [token_counts[i] for i in seg_indices]
+        parent = _assemble_parent(
+            parent_segments,
+            parent_token_counts,
+            position=parent_idx,
+            target_child_tokens=target_child_tokens,
+            max_child_tokens=max_child_tokens,
+        )
+        result.append(parent)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _paragraph_of(segment_id: str) -> str | None:
+    """Return the paragraph key from a bilara segment id, or None.
+
+    ``mn1:3.2`` → ``"3"``. ``mn-name:1.mn-mulapannasa`` → ``None``
+    (paragraph number is non-numeric). ``None`` disables the boundary
+    heuristic for that segment — we fall back to token-count-only
+    splitting, which is the safe default.
+    """
+    m = _PARAGRAPH_RE.match(segment_id)
+    if m is None:
+        return None
+    return m.group(1)
+
+
+def _assemble_parent(
+    segments: Sequence[SegmentInput],
+    token_counts: Sequence[int],
+    *,
+    position: int,
+    target_child_tokens: int,
+    max_child_tokens: int,
+) -> ParentChunk:
+    """Build one ParentChunk from a slice of segments + slice children."""
+    parent_text = " ".join(s.text for s in segments).strip()
+    parent_tokens = sum(token_counts)
+    parent_segment_ids = [s.segment_id for s in segments]
+
+    # Slice into children using the same "accumulate until target,
+    # emit" pattern, breaking on any segment boundary.
+    children: list[ChildChunk] = []
+    buffer_indices: list[int] = []
+    buffer_tokens = 0
+
+    for i in range(len(segments)):
+        seg_tokens = token_counts[i]
+        would_overflow = buffer_tokens + seg_tokens > max_child_tokens
+        at_target = buffer_tokens >= target_child_tokens
+
+        if buffer_indices and (at_target or would_overflow):
+            children.append(
+                _make_child(
+                    [segments[j] for j in buffer_indices],
+                    [token_counts[j] for j in buffer_indices],
+                    position_in_parent=len(children),
+                )
+            )
+            buffer_indices = []
+            buffer_tokens = 0
+
+        buffer_indices.append(i)
+        buffer_tokens += seg_tokens
+
+    if buffer_indices:
+        children.append(
+            _make_child(
+                [segments[j] for j in buffer_indices],
+                [token_counts[j] for j in buffer_indices],
+                position_in_parent=len(children),
+            )
+        )
+
+    return ParentChunk(
+        text=parent_text,
+        token_count=parent_tokens,
+        segment_ids=parent_segment_ids,
+        position=position,
+        children=children,
+    )
+
+
+def _make_child(
+    segments: Sequence[SegmentInput],
+    token_counts: Sequence[int],
+    *,
+    position_in_parent: int,
+) -> ChildChunk:
+    return ChildChunk(
+        text=" ".join(s.text for s in segments).strip(),
+        token_count=sum(token_counts),
+        segment_ids=[s.segment_id for s in segments],
+        position_in_parent=position_in_parent,
+    )

--- a/tests/integration/test_sc_loader.py
+++ b/tests/integration/test_sc_loader.py
@@ -87,7 +87,9 @@ async def test_load_file_creates_full_frbr_hierarchy(
     await db_session.commit()
 
     assert not result.skipped
-    assert result.chunks_inserted == 4
+    # 1 parent + 1 child for this tiny sutta (all 4 segments fit under
+    # a single parent and a single child by token count).
+    assert result.chunks_inserted == 2
 
     work = (
         await db_session.execute(sa.select(Work).where(Work.canonical_id == "mn1"))
@@ -132,17 +134,23 @@ async def test_load_file_creates_full_frbr_hierarchy(
         .scalars()
         .all()
     )
-    assert len(chunks) == 4
-    assert [c.segment_id for c in chunks] == [
-        "mn1:0.1",
-        "mn1:0.2",
-        "mn1:1.1",
-        "mn1:1.2",
-    ]
-    assert all(c.is_parent is False for c in chunks)
-    # Cleaner strips trailing whitespace and populates the fold column.
-    assert chunks[0].text == "Middle Discourses 1"
-    assert chunks[0].text_ascii_fold == "Middle Discourses 1"
+    assert len(chunks) == 2
+    parent, child = chunks
+    assert parent.is_parent is True
+    assert parent.parent_chunk_id is None
+    assert parent.metadata_json["segment_ids"] == ["mn1:0.1", "mn1:0.2", "mn1:1.1", "mn1:1.2"]
+    # Parent text is the joined canonical text of all four segments.
+    assert parent.text.startswith("Middle Discourses 1")
+    assert "At one time the Buddha" in parent.text
+
+    assert child.is_parent is False
+    assert child.parent_chunk_id == parent.id
+    assert child.metadata_json["position_in_parent"] == 0
+    # Child covers the same segments when the parent is short enough.
+    assert child.metadata_json["segment_ids"] == parent.metadata_json["segment_ids"]
+    # ASCII fold column is populated on both kinds of chunk.
+    assert parent.text_ascii_fold is not None and parent.text_ascii_fold.isascii()
+    assert child.text_ascii_fold is not None
 
 
 async def test_load_file_is_idempotent_via_content_hash(
@@ -175,7 +183,8 @@ async def test_load_file_is_idempotent_via_content_hash(
         await db_session.execute(sa.select(sa.func.count()).select_from(Chunk))
     ).scalar_one()
     assert total_instances == 1
-    assert total_chunks == 4
+    # 1 parent + 1 child after structural chunking of a 4-segment sutta.
+    assert total_chunks == 2
 
 
 async def test_load_file_rejects_unknown_author(
@@ -212,10 +221,19 @@ async def test_load_directory_handles_multiple_works(
     assert counters["files_seen"] == 2
     assert counters["files_loaded"] == 2
     assert counters["files_skipped"] == 0
-    assert counters["chunks_inserted"] == 4 + 3  # mn1 has 4, mn2 has 3
+    # Each short sutta collapses to 1 parent + 1 child under default
+    # token targets, so 2 files × 2 chunks = 4.
+    assert counters["chunks_inserted"] == 4
 
     works = (await db_session.execute(sa.select(Work))).scalars().all()
     assert {w.canonical_id for w in works} == {"mn1", "mn2"}
+
+    # Every child must point at a real parent.
+    all_chunks = (await db_session.execute(sa.select(Chunk))).scalars().all()
+    parents_by_id = {c.id: c for c in all_chunks if c.is_parent}
+    for chunk in all_chunks:
+        if not chunk.is_parent:
+            assert chunk.parent_chunk_id in parents_by_id
 
 
 async def test_cleaner_produces_ascii_fold_for_pali_segments(
@@ -246,15 +264,69 @@ async def test_cleaner_produces_ascii_fold_for_pali_segments(
     await db_session.commit()
 
     chunks = (await db_session.execute(sa.select(Chunk).order_by(Chunk.sequence))).scalars().all()
-    assert len(chunks) == 3
-    # Canonical: whitespace stripped, diacritics preserved.
-    assert chunks[1].text == "Satipaṭṭhānasutta"
-    assert chunks[2].text == "Evaṃ me sutaṃ—saṅghe nibbānañca."
-    # ASCII fold column must be ASCII-only and diacritic-free.
-    assert chunks[1].text_ascii_fold == "Satipatthanasutta"
-    assert chunks[2].text_ascii_fold == "Evam me sutam—sanghe nibbananca."
-    assert chunks[2].text_ascii_fold is not None
-    assert chunks[2].text_ascii_fold.isascii() is False  # em-dash is not ASCII
-    # But every non-em-dash character must be ASCII — the diacritics are gone.
-    fold_without_dash = chunks[2].text_ascii_fold.replace("—", " ")
+    # Three short segments collapse into one parent + one child.
+    assert len(chunks) == 2
+    parent, child = chunks
+    assert parent.is_parent is True
+    assert child.is_parent is False and child.parent_chunk_id == parent.id
+
+    # Canonical text preserves diacritics; both kinds of chunk carry it.
+    assert "Satipaṭṭhānasutta" in parent.text
+    assert "nibbānañca" in parent.text
+    assert "Satipaṭṭhānasutta" in child.text
+
+    # ASCII fold exists on both rows, diacritics stripped, em-dash kept.
+    assert parent.text_ascii_fold is not None
+    assert child.text_ascii_fold is not None
+    assert "Satipatthanasutta" in parent.text_ascii_fold
+    assert "nibbananca" in parent.text_ascii_fold
+    fold_without_dash = parent.text_ascii_fold.replace("—", " ")
     assert fold_without_dash.isascii()
+
+
+# ---------------------------------------------------------------------------
+# scripts/rechunk.py — idempotency
+# ---------------------------------------------------------------------------
+
+
+async def test_rechunk_on_fresh_ingest_is_noop(
+    db_session: AsyncSession,
+    sc_tree: Path,
+) -> None:
+    """Running rechunk over an Instance already in parent/child form skips it.
+
+    Day-4 ingest produced flat chunks that had to be migrated on day 7.
+    From day 7 onwards the loader emits parent/child directly, so a
+    later rechunk has nothing to do. This test guards that invariant
+    so the script stays safe to re-run as a cron.
+    """
+    from scripts.rechunk import _rechunk_one_instance
+
+    path = (
+        sc_tree
+        / "translation"
+        / "en"
+        / "sujato"
+        / "sutta"
+        / "mn"
+        / "mn1_translation-en-sujato.json"
+    )
+    bf = parse_bilara_file(path, sc_tree)
+    await load_file(db_session, bf)
+    await db_session.commit()
+
+    instance_id = (await db_session.execute(sa.select(Instance.id).limit(1))).scalar_one()
+
+    deleted, inserted, skipped = await _rechunk_one_instance(db_session, instance_id)
+    assert (deleted, inserted, skipped) == (0, 0, 1)
+
+    # Running again must also skip and never touch data.
+    chunks_before = (
+        await db_session.execute(sa.select(sa.func.count()).select_from(Chunk))
+    ).scalar_one()
+    deleted2, inserted2, skipped2 = await _rechunk_one_instance(db_session, instance_id)
+    assert (deleted2, inserted2, skipped2) == (0, 0, 1)
+    chunks_after = (
+        await db_session.execute(sa.select(sa.func.count()).select_from(Chunk))
+    ).scalar_one()
+    assert chunks_after == chunks_before

--- a/tests/unit/processing/test_chunker.py
+++ b/tests/unit/processing/test_chunker.py
@@ -1,0 +1,306 @@
+"""Unit tests for the parent-child chunker.
+
+Covers four concerns:
+
+* Boundary behaviour: parents break on paragraph boundaries,
+  children break inside parents.
+* Overflow: when a single segment is bigger than a target/max,
+  the algorithm doesn't loop forever and emits reasonable output.
+* Metadata: ``segment_ids``, ``position``, ``position_in_parent``
+  are correctly stamped — retrieval depends on them.
+* Edge cases: empty input, single segment, non-numeric paragraph
+  keys, Pali text with diacritics.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.processing.chunker import (
+    MAX_CHILD_TOKENS,
+    MAX_PARENT_TOKENS,
+    SegmentInput,
+    chunk_segments,
+    default_token_count,
+)
+
+
+def _seg(segment_id: str, text: str) -> SegmentInput:
+    return SegmentInput(segment_id=segment_id, text=text)
+
+
+def _word(n: int) -> str:
+    """Return a string with exactly ``n`` words, easy for token maths."""
+    return " ".join(f"w{i}" for i in range(n))
+
+
+# ---------------------------------------------------------------------------
+# default_token_count heuristic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("", 1),  # floor at 1 so every segment contributes
+        ("hello world", 3),  # 2 words * 1.3 = 2.6 → round to 3
+        ("one two three four five", 6),  # 5 * 1.3 = 6.5 → 6 (banker's rounding)
+        (" ".join(["word"] * 10), 13),  # 10 * 1.3 = 13
+    ],
+)
+def test_default_token_count(text: str, expected: int) -> None:
+    assert default_token_count(text) == expected
+
+
+# ---------------------------------------------------------------------------
+# Empty / trivial inputs
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_returns_empty_list() -> None:
+    assert chunk_segments([]) == []
+
+
+def test_single_tiny_segment_produces_one_parent_one_child() -> None:
+    result = chunk_segments(
+        [_seg("mn1:1.1", "So I have heard.")],
+    )
+    assert len(result) == 1
+    parent = result[0]
+    assert parent.position == 0
+    assert parent.segment_ids == ["mn1:1.1"]
+    assert parent.text == "So I have heard."
+    assert len(parent.children) == 1
+    assert parent.children[0].segment_ids == ["mn1:1.1"]
+    assert parent.children[0].position_in_parent == 0
+
+
+# ---------------------------------------------------------------------------
+# Parent boundary on paragraph break
+# ---------------------------------------------------------------------------
+
+
+def test_parent_break_at_paragraph_boundary_when_target_reached() -> None:
+    """After target_parent_tokens is reached, the next paragraph triggers a break."""
+    # Use 3 paragraphs, each ~120 tokens (enough that paragraph 1+2 is
+    # above a 200-token target).
+    segs = [
+        _seg("mn1:1.1", _word(90)),  # para 1, ~117 tokens (90*1.3)
+        _seg("mn1:2.1", _word(90)),  # para 2 — after para 1 we're at target
+        _seg("mn1:3.1", _word(90)),  # para 3 — new parent starts here
+    ]
+    result = chunk_segments(
+        segs,
+        target_parent_tokens=200,
+        max_parent_tokens=500,
+        target_child_tokens=500,  # avoid child splits interfering
+        max_child_tokens=500,
+    )
+    # Expected: parent 1 = [1.1, 2.1] (≈234 tokens, broke at para 3),
+    # parent 2 = [3.1].
+    assert len(result) == 2
+    assert result[0].segment_ids == ["mn1:1.1", "mn1:2.1"]
+    assert result[1].segment_ids == ["mn1:3.1"]
+    assert result[0].position == 0
+    assert result[1].position == 1
+
+
+def test_parent_stays_within_paragraph_below_target() -> None:
+    """If under target, do not close even on paragraph boundary."""
+    segs = [
+        _seg("mn1:1.1", _word(10)),
+        _seg("mn1:2.1", _word(10)),
+        _seg("mn1:3.1", _word(10)),
+    ]
+    result = chunk_segments(
+        segs,
+        target_parent_tokens=200,
+        max_parent_tokens=500,
+    )
+    # All three paragraphs fit in one parent (3 * 13 = 39 tokens, way
+    # below 200 target).
+    assert len(result) == 1
+    assert len(result[0].segment_ids) == 3
+
+
+# ---------------------------------------------------------------------------
+# Hard overflow safety valve
+# ---------------------------------------------------------------------------
+
+
+def test_parent_force_closes_at_max_even_without_paragraph_break() -> None:
+    """If max is about to be exceeded, close mid-paragraph."""
+    segs = [
+        _seg("mn1:1.1", _word(200)),  # ~260 tokens
+        _seg("mn1:1.2", _word(200)),  # adding this would exceed max=400
+        _seg("mn1:1.3", _word(200)),
+    ]
+    result = chunk_segments(
+        segs,
+        target_parent_tokens=1000,  # far away
+        max_parent_tokens=400,
+        target_child_tokens=1000,
+        max_child_tokens=1000,
+    )
+    # Every segment stands alone because adding a second one (≈260 + 260
+    # = 520) exceeds max=400.
+    assert len(result) == 3
+    assert [p.segment_ids for p in result] == [
+        ["mn1:1.1"],
+        ["mn1:1.2"],
+        ["mn1:1.3"],
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Children inside a parent
+# ---------------------------------------------------------------------------
+
+
+def test_children_split_at_segment_boundaries() -> None:
+    """A long parent gets sliced into children on segment boundaries."""
+    segs = [
+        _seg("mn1:1.1", _word(50)),  # 65 tokens
+        _seg("mn1:1.2", _word(50)),
+        _seg("mn1:1.3", _word(50)),
+        _seg("mn1:1.4", _word(50)),
+        _seg("mn1:1.5", _word(50)),
+        _seg("mn1:1.6", _word(50)),
+    ]
+    result = chunk_segments(
+        segs,
+        target_parent_tokens=10_000,  # keep everything in one parent
+        max_parent_tokens=10_000,
+        target_child_tokens=100,  # two segments per child (2*65=130)
+        max_child_tokens=200,
+    )
+    assert len(result) == 1
+    parent = result[0]
+    # 6 segments × 65 tokens = 390 total; children ~130 each → 3 children.
+    assert len(parent.children) == 3
+    for i, child in enumerate(parent.children):
+        assert child.position_in_parent == i
+        assert len(child.segment_ids) == 2
+
+
+def test_children_cover_all_parent_segments_in_order() -> None:
+    """Every parent segment appears in exactly one child, same order."""
+    segs = [_seg(f"mn1:1.{i}", _word(40)) for i in range(1, 11)]
+    result = chunk_segments(segs)
+    for parent in result:
+        flat: list[str] = []
+        for child in parent.children:
+            flat.extend(child.segment_ids)
+        assert flat == parent.segment_ids
+
+
+# ---------------------------------------------------------------------------
+# Metadata / positions
+# ---------------------------------------------------------------------------
+
+
+def test_parent_positions_are_0_indexed_and_contiguous() -> None:
+    segs = [_seg(f"mn1:{p}.1", _word(200)) for p in range(1, 6)]
+    result = chunk_segments(
+        segs,
+        target_parent_tokens=200,
+        max_parent_tokens=500,
+    )
+    for i, parent in enumerate(result):
+        assert parent.position == i
+
+
+def test_parent_text_joins_segments_with_single_space() -> None:
+    """No leading/trailing whitespace; segments separated by a single space."""
+    segs = [
+        _seg("mn1:1.1", "Hello"),
+        _seg("mn1:1.2", "world"),
+        _seg("mn1:1.3", "."),
+    ]
+    result = chunk_segments(segs)
+    assert result[0].text == "Hello world ."  # join strips trailing only
+
+
+def test_token_count_matches_sum_of_segments() -> None:
+    segs = [
+        _seg("mn1:1.1", _word(50)),
+        _seg("mn1:1.2", _word(30)),
+    ]
+    result = chunk_segments(segs)
+    parent = result[0]
+    expected = default_token_count(segs[0].text) + default_token_count(segs[1].text)
+    assert parent.token_count == expected
+
+
+# ---------------------------------------------------------------------------
+# Pali / Unicode sanity
+# ---------------------------------------------------------------------------
+
+
+def test_pali_diacritics_pass_through_unchanged() -> None:
+    segs = [
+        _seg("mn10:1.1", "Satipaṭṭhānasutta"),
+        _seg("mn10:1.2", "Evaṃ me sutaṃ saññā nibbāna"),
+    ]
+    result = chunk_segments(segs)
+    assert "Satipaṭṭhānasutta" in result[0].text
+    assert "nibbāna" in result[0].text
+    assert "Satipaṭṭhānasutta" in result[0].children[0].text
+
+
+def test_non_numeric_paragraph_keys_fall_back_to_token_limits() -> None:
+    """When paragraph can't be parsed, we only break on token limits."""
+    segs = [
+        _seg("mn-name:1.mn-mulapannasa", _word(100)),
+        _seg("mn-name:2.mn-vagga", _word(100)),
+    ]
+    # With target 10k and max 10k these should stay together.
+    result = chunk_segments(
+        segs,
+        target_parent_tokens=10_000,
+        max_parent_tokens=10_000,
+    )
+    assert len(result) == 1
+    assert len(result[0].segment_ids) == 2
+
+
+# ---------------------------------------------------------------------------
+# Injected token counter
+# ---------------------------------------------------------------------------
+
+
+def test_custom_token_counter_changes_break_points() -> None:
+    """Prove the DI seam: a counter that claims huge counts forces splits."""
+
+    def huge_counter(_: str) -> int:
+        return 1000  # every segment "costs" 1000 tokens
+
+    segs = [_seg(f"mn1:1.{i}", "x") for i in range(3)]
+    result = chunk_segments(
+        segs,
+        target_parent_tokens=500,
+        max_parent_tokens=900,
+        count_tokens=huge_counter,
+    )
+    # Each segment alone overflows max=900 when buffered with another,
+    # so we expect 3 parents.
+    assert len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# Realistic default sizes — smoke test on a miniature sutta
+# ---------------------------------------------------------------------------
+
+
+def test_defaults_produce_reasonable_chunking_on_realistic_corpus() -> None:
+    # Simulate an MN-style sutta: ~30 paragraphs, 5 sentences each,
+    # ~15 words/sentence. About 2250 total tokens — should yield
+    # 1-2 parents with several children each.
+    segs = [_seg(f"mn10:{p}.{s}", _word(15)) for p in range(1, 31) for s in range(1, 6)]
+    result = chunk_segments(segs)
+    assert 1 <= len(result) <= 3, f"unexpected parent count: {len(result)}"
+    for parent in result:
+        assert parent.token_count <= MAX_PARENT_TOKENS
+        assert len(parent.children) >= 1
+        for child in parent.children:
+            assert child.token_count <= MAX_CHILD_TOKENS


### PR DESCRIPTION
## Summary

Turns one sutta into a parent/child chunk hierarchy (Parent Document Retrieval pattern).

- **Children** (~384 tokens): drive BGE-M3 dense / sparse / BM25 search — one idea per chunk.
- **Parents** (~1536 tokens, cap 2048): what Claude sees as context. Structurally aware, break at paragraph boundaries.

Applied review findings from the dharma-code-reviewer persona (via general-purpose subagent in this session — custom agents will load in next VS Code restart).

## Live DB result

On the 3,413 sujato MN/DN/SN/AN Instances:

| | Before (rag-day-04) | After (rag-day-07) |
|---|---|---|
| Total chunks | 124,532 | **10,227** |
| Shape | 1 flat chunk per bilara segment | 3,749 parents + 6,478 children |
| Parent avg/max tokens | N/A | 458 / 2048 |
| Child avg/max tokens | N/A | 265 / 508 |
| Orphan children | N/A | **0** |

Rechunk on 3,413 Instances: 48 s.

## Files

- NEW src/processing/chunker.py (pure, dependency-injected TokenCounter)
- NEW tests/unit/processing/test_chunker.py (18 tests)
- NEW scripts/rechunk.py (in-place backfill, idempotent)
- MODIFIED src/ingest/suttacentral/loader.py (emits parent+child natively now)
- MODIFIED tests/integration/test_sc_loader.py (+test_rechunk_on_fresh_ingest_is_noop)

## Tests

79 passing (65 unit + 14 integration), ruff/mypy clean.

## Deferred to follow-up

- N+1 flush in parent insertion
- Paragraph-break-aware join
- Clearer naming of parent.segment_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)