### PR TITLE
feat(rag): rag-day-10 Qdrant indexing + 6478-chunk full ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ## [Unreleased]
 
+### Added
+- **rag-day-10 (partial — code ready, GPU ingest pending):** Qdrant indexer in `src/embeddings/indexer.py`. Named-vector collection `dharma_v1` (1024-d dense BGE-M3 cosine + learned sparse). Pure DI via `QdrantClientProtocol` + `EncoderProtocol` so unit tests run without Qdrant or CUDA (19 unit tests, 98% coverage). Integration tests verify real qdrant-client 1.17 accepts the `PointStruct` shape, `query_points` round-trips dense/sparse, identity-vector query returns cosine 1.0, and re-upsert on the same chunk UUID is idempotent (5 integration tests). CLI `scripts/index_qdrant.py` streams from Postgres with keyset pagination on `chunk.id`, filters to child chunks by default (`--include-parents` to override), supports `--limit N` for smoke runs and `--recreate` to drop the collection. Continue-on-error orchestration: a failed batch is logged, captured in `IndexerStats.failed_batches`, and the run proceeds past it.
+
 ---
 
 ## [0.0.3] — 2026-04-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,14 @@
 ## [Unreleased]
 
 ### Added
-- **rag-day-10 (partial — code ready, GPU ingest pending):** Qdrant indexer in `src/embeddings/indexer.py`. Named-vector collection `dharma_v1` (1024-d dense BGE-M3 cosine + learned sparse). Pure DI via `QdrantClientProtocol` + `EncoderProtocol` so unit tests run without Qdrant or CUDA (19 unit tests, 98% coverage). Integration tests verify real qdrant-client 1.17 accepts the `PointStruct` shape, `query_points` round-trips dense/sparse, identity-vector query returns cosine 1.0, and re-upsert on the same chunk UUID is idempotent (5 integration tests). CLI `scripts/index_qdrant.py` streams from Postgres with keyset pagination on `chunk.id`, filters to child chunks by default (`--include-parents` to override), supports `--limit N` for smoke runs and `--recreate` to drop the collection. Continue-on-error orchestration: a failed batch is logged, captured in `IndexerStats.failed_batches`, and the run proceeds past it.
+- **rag-day-10:** Qdrant indexer in `src/embeddings/indexer.py`. Named-vector collection `dharma_v1` (1024-d dense BGE-M3 cosine + learned sparse). Pure DI via `QdrantClientProtocol` + `EncoderProtocol` so unit tests run without Qdrant or CUDA (19 unit tests, 98% coverage). Integration tests verify real qdrant-client 1.17 accepts the `PointStruct` shape, `query_points` round-trips dense/sparse, identity-vector query returns cosine 1.0, and re-upsert on the same chunk UUID is idempotent (5 integration tests). CLI `scripts/index_qdrant.py` streams from Postgres with keyset pagination on `chunk.id`, filters to child chunks by default (`--include-parents` to override), supports `--limit N` for smoke runs and `--recreate` to drop the collection. **Full corpus indexed on GPU: 6,478 child chunks in 4:40 min on the 1080 Ti with fp16 (~23 chunks/sec), 0 failed batches.** `scripts/smoke_retrieval.py` runs a curated set of canonical queries (English paraphrase, Pali with/without diacritics, Russian cross-lingual) and prints dense + sparse top-3 with scores and text — qualitative sanity gate before the numeric eval on day 14.
+- **Toolchain:** torch upgraded 2.5.1+cu121 → 2.6.0+cu124 (CVE-2025-32434 + transformers 4.57 pickle-loader gate). huggingface-hub pinned back to `<1.0` to match transformers 4.x. Both were latent conflicts from day-8; day-10 forced the resolution.
+
+### Qualitative retrieval results (day-10 baseline, pre-reranker)
+- 🟢 English paraphrase → canonical sutta: `mindfulness of breathing` → **MN 118 Anāpānassati** (0.700)
+- 🟢 English doctrinal term → right collection: `four noble truths` → **SN 56.27** (0.714)
+- 🟢 Cross-lingual: `страдание` (Russian) → **DN 22 Mahāsatipaṭṭhāna** (0.624)
+- 🔴 Bare Pali term weak without reranker: `satipaṭṭhāna` does not retrieve MN 10 (top score 0.49); motivates day-11 hybrid + day-13 reranker.
 
 ---
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,10 +5,10 @@
 >
 > **Source of truth:** git log + этот файл. Чаты не являются source of truth.
 
-- **Версия:** 2026-04-21
-- **Ветка:** `dev`
-- **Последний релиз:** нет (pre-alpha)
-- **Следующий milestone:** v0.1.0 Foundation
+- **Версия:** 2026-04-22
+- **Ветка:** `dev` (активная: `feat/rag-day-10-qdrant-indexing`)
+- **Последний релиз:** `v0.0.3` — Retrieval Foundation (2026-04-22)
+- **Следующий milestone:** v0.1.0 Foundation (rag-day-21)
 - **Стратегия:** **B** — RAG-first до `v0.1.0` (`rag-day-21`), затем интерливинг RAG+APP
 
 ---
@@ -38,7 +38,8 @@
 | rag-day-06 | Cleaner: Unicode NFC, Pali диакритика (IAST + ASCII-fold) | ✅ Done | `ce186c5` |
 | rag-day-07 | Структурный chunker (384 child / 1024-2048 parent) | ✅ Done | `6c8ff98` |
 | rag-day-08 | FlagEmbedding + BGE-M3 (dense + sparse на 100 чанках) | ✅ Done | `9f7e092` |
-| rag-day-09 | Phoenix observability + OpenInference | ✅ Done | (this branch) |
+| rag-day-09 | Phoenix observability + OpenInference | ✅ Done | `c2defe2` |
+| rag-day-10 | Qdrant collection `dharma_v1` + named vectors + full ingest | 🚧 In progress | (this branch) |
 | … | (всего 120 дней в плане) | | |
 
 ### App-трек

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -39,7 +39,7 @@
 | rag-day-07 | Структурный chunker (384 child / 1024-2048 parent) | ✅ Done | `6c8ff98` |
 | rag-day-08 | FlagEmbedding + BGE-M3 (dense + sparse на 100 чанках) | ✅ Done | `9f7e092` |
 | rag-day-09 | Phoenix observability + OpenInference | ✅ Done | `c2defe2` |
-| rag-day-10 | Qdrant collection `dharma_v1` + named vectors + full ingest | 🚧 In progress | (this branch) |
+| rag-day-10 | Qdrant collection `dharma_v1` + named vectors + full ingest (6478 child chunks, 4:40 min on 1080 Ti) | ✅ Done | (this branch) |
 | … | (всего 120 дней в плане) | | |
 
 ### App-трек

--- a/scripts/index_qdrant.py
+++ b/scripts/index_qdrant.py
@@ -1,0 +1,277 @@
+"""Index chunks from Postgres into Qdrant via BGE-M3 encoding.
+
+Usage (from repo root, with ``docker compose up -d`` running both
+``dharma-db`` and ``qdrant``)::
+
+    # Full corpus on GPU (expected ~25 min on a 1080 Ti with fp16)
+    python scripts/index_qdrant.py
+
+    # Test on 100 chunks first — good sanity check before the full run
+    python scripts/index_qdrant.py --limit 100
+
+    # Drop and recreate the collection before indexing
+    python scripts/index_qdrant.py --recreate
+
+    # Explicitly pin device (defaults to "auto")
+    python scripts/index_qdrant.py --device cuda
+
+Only **child chunks** (``is_parent=false``) are indexed by default —
+retrieval is done on children, and parents are looked up via FK when
+returning context to the LLM. Pass ``--include-parents`` if you want
+the entire chunk table for some other experiment.
+
+The script streams from Postgres in batches of ``--batch-size`` rows,
+encodes each batch on the GPU, and upserts into Qdrant. Interrupting
+and re-running is safe — upserts key by the chunk UUID.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+import time
+from collections.abc import AsyncIterator
+from pathlib import Path
+from uuid import UUID
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+import sqlalchemy as sa  # noqa: E402
+from qdrant_client import QdrantClient  # noqa: E402
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine  # noqa: E402
+
+from src.config import get_settings  # noqa: E402
+from src.db.models.frbr import Chunk, Expression, Instance, Work  # noqa: E402
+from src.embeddings.bge_m3 import BGEM3Encoder  # noqa: E402
+from src.embeddings.indexer import (  # noqa: E402
+    COLLECTION_NAME,
+    ChunkForIndexing,
+    ensure_collection,
+    index_corpus,
+)
+
+logger = logging.getLogger("index_qdrant")
+
+
+async def _stream_chunks(
+    session_maker: async_sessionmaker[sa.ext.asyncio.AsyncSession],
+    *,
+    batch_size: int,
+    include_parents: bool,
+    limit: int | None,
+) -> AsyncIterator[list[ChunkForIndexing]]:
+    """Yield chunk batches joined with Work metadata.
+
+    One query per batch, keyset-paginated on ``chunk.id`` for stable
+    ordering regardless of insert time. An offset pagination would
+    also work at our scale (~10k rows) but keyset is future-proofed
+    for when the corpus hits six figures.
+    """
+    last_id: UUID | None = None
+    chunks_yielded = 0
+
+    async with session_maker() as session:
+        while True:
+            stmt = (
+                sa.select(
+                    Chunk.id,
+                    Chunk.text,
+                    Chunk.parent_chunk_id,
+                    Chunk.instance_id,
+                    Chunk.sequence,
+                    Chunk.is_parent,
+                    Chunk.token_count,
+                    Chunk.segment_id,
+                    Chunk.pericope_id,
+                    Work.canonical_id.label("work_canonical_id"),
+                )
+                .select_from(Chunk)
+                .join(Instance, Instance.id == Chunk.instance_id)
+                .join(Expression, Expression.id == Instance.expression_id)
+                .join(Work, Work.id == Expression.work_id)
+                .order_by(Chunk.id)
+                .limit(batch_size)
+            )
+            if not include_parents:
+                stmt = stmt.where(Chunk.is_parent.is_(False))
+            if last_id is not None:
+                stmt = stmt.where(Chunk.id > last_id)
+
+            rows = (await session.execute(stmt)).all()
+            if not rows:
+                return
+
+            batch = [
+                ChunkForIndexing(
+                    chunk_id=row.id,
+                    text=row.text,
+                    parent_chunk_id=row.parent_chunk_id,
+                    instance_id=row.instance_id,
+                    work_canonical_id=row.work_canonical_id,
+                    segment_id=row.segment_id,
+                    sequence=row.sequence,
+                    is_parent=row.is_parent,
+                    token_count=row.token_count,
+                    pericope_id=row.pericope_id,
+                )
+                for row in rows
+            ]
+
+            # Apply --limit *after* we've filled a batch so we still
+            # emit exactly `limit` chunks across the run (modulo the
+            # final batch being shorter than batch_size).
+            if limit is not None and chunks_yielded + len(batch) > limit:
+                batch = batch[: limit - chunks_yielded]
+                if batch:
+                    yield batch
+                    chunks_yielded += len(batch)
+                return
+
+            yield batch
+            chunks_yielded += len(batch)
+            last_id = rows[-1].id
+
+            if len(rows) < batch_size:
+                return
+
+
+async def _run(args: argparse.Namespace) -> int:
+    settings = get_settings()
+
+    engine = create_async_engine(settings.database_url, future=True, echo=False)
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    # QdrantClient is sync — fine here, the embed step dominates wall
+    # time and upsert is a single HTTP/gRPC round-trip. Using the async
+    # client would complicate the mixed sync-encoder / sync-client path
+    # for no measurable win on 10k points.
+    client = QdrantClient(url=settings.qdrant_url)
+
+    logger.info("Ensuring collection %r exists (recreate=%s)", COLLECTION_NAME, args.recreate)
+    ensure_collection(client, recreate=args.recreate)
+
+    logger.info(
+        "Building encoder (device=%s, fp16=%s, model=BAAI/bge-m3)",
+        args.device,
+        args.use_fp16,
+    )
+    encoder = BGEM3Encoder(
+        device=args.device,
+        use_fp16=None if args.use_fp16 == "auto" else args.use_fp16 == "true",
+    )
+
+    # Eager-load so the device log line prints before the first batch.
+    _ = encoder.device
+    logger.info("Encoder ready: device=%s fp16=%s", encoder.device, encoder.uses_fp16)
+
+    start = time.monotonic()
+    try:
+        stats = await index_corpus(
+            client=client,
+            encoder=encoder,
+            batches=_stream_chunks(
+                session_maker,
+                batch_size=args.batch_size,
+                include_parents=args.include_parents,
+                limit=args.limit,
+            ),
+            encoder_batch_size=args.encoder_batch_size,
+            encoder_max_length=args.encoder_max_length,
+        )
+    finally:
+        await engine.dispose()
+        client.close()
+    elapsed = time.monotonic() - start
+
+    count = client.count(COLLECTION_NAME, exact=True)
+
+    print(
+        "\n=== Indexing summary ===\n"
+        f"  batches processed: {stats.batches_processed:>6}\n"
+        f"  chunks encoded:    {stats.chunks_encoded:>6}\n"
+        f"  points upserted:   {stats.points_upserted:>6}\n"
+        f"  skipped empty:     {stats.skipped_empty:>6}\n"
+        f"  failed batches:    {len(stats.failed_batches):>6}"
+        f"{'  ' + str(stats.failed_batches) if stats.failed_batches else ''}\n"
+        f"  collection size:   {count.count:>6} (after run)\n"
+        f"  elapsed:           {elapsed:>6.1f}s"
+    )
+    return 0 if not stats.failed_batches else 1
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+    )
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=64,
+        help="Rows per Postgres fetch and per Qdrant upsert (default: 64).",
+    )
+    parser.add_argument(
+        "--encoder-batch-size",
+        type=int,
+        default=12,
+        help=(
+            "Internal BGE-M3 batch size — how many texts encode() processes "
+            "in one forward pass (default: 12, safe for 11 GB VRAM with fp16)."
+        ),
+    )
+    parser.add_argument(
+        "--encoder-max-length",
+        type=int,
+        default=2048,
+        help="BGE-M3 max_length token budget (default: 2048, matches parent cap).",
+    )
+    parser.add_argument(
+        "--device",
+        default="auto",
+        choices=["auto", "cuda", "cpu"],
+        help="Where to run BGE-M3 (default: auto — CUDA if available, else CPU).",
+    )
+    parser.add_argument(
+        "--use-fp16",
+        default="auto",
+        choices=["auto", "true", "false"],
+        help=(
+            "fp16 precision. 'auto' = fp16 on CUDA, fp32 on CPU (recommended). "
+            "Forcing 'true' on CPU gives no speed-up and may hurt quality."
+        ),
+    )
+    parser.add_argument(
+        "--recreate",
+        action="store_true",
+        help="Drop and recreate the collection before indexing.",
+    )
+    parser.add_argument(
+        "--include-parents",
+        action="store_true",
+        help=(
+            "Index parent chunks too (default: children only). Retrieval "
+            "uses children; parents are fetched via FK when returning context."
+        ),
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Stop after N chunks — useful for smoke-testing on a small slice.",
+    )
+    args = parser.parse_args()
+
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/index_qdrant.py
+++ b/scripts/index_qdrant.py
@@ -185,12 +185,11 @@ async def _run(args: argparse.Namespace) -> int:
             encoder_batch_size=args.encoder_batch_size,
             encoder_max_length=args.encoder_max_length,
         )
+        elapsed = time.monotonic() - start
+        count = client.count(COLLECTION_NAME, exact=True)
     finally:
         await engine.dispose()
         client.close()
-    elapsed = time.monotonic() - start
-
-    count = client.count(COLLECTION_NAME, exact=True)
 
     print(
         "\n=== Indexing summary ===\n"

--- a/scripts/smoke_retrieval.py
+++ b/scripts/smoke_retrieval.py
@@ -1,0 +1,153 @@
+"""End-to-end retrieval smoke test against Qdrant + Postgres.
+
+Runs a fixed set of canonical queries (English + Pali + Russian),
+encodes each one with BGE-M3, fetches top-K from Qdrant using both
+dense and sparse named vectors separately, then joins the hits back
+to ``chunk.text`` in Postgres so a human reviewer can eyeball the
+results.
+
+This is a qualitative gate, not a numeric one — the numeric gate is
+Ragas/LLM-judge eval on day 14. What we want to see here:
+
+* Canonical Pali terms (``anapanasati``, ``satipaṭṭhāna``) surface
+  passages from the right suttas (MN 10, MN 118).
+* An English paraphrase retrieves something related even when the
+  exact Pali string does not appear.
+* Dense and sparse disagree on some queries — that is the whole
+  point of keeping both for later hybrid fusion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from uuid import UUID
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+import sqlalchemy as sa  # noqa: E402
+from qdrant_client import QdrantClient  # noqa: E402
+from qdrant_client.models import SparseVector  # noqa: E402
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine  # noqa: E402
+
+from src.config import get_settings  # noqa: E402
+from src.db.models.frbr import Chunk  # noqa: E402
+from src.embeddings.bge_m3 import BGEM3Encoder  # noqa: E402
+from src.embeddings.indexer import (  # noqa: E402
+    COLLECTION_NAME,
+    DENSE_VECTOR_NAME,
+    SPARSE_VECTOR_NAME,
+)
+
+# Carefully curated so a Buddhism-literate reader can tell at a glance
+# whether retrieval is sensible: each query has an expected "this should
+# hit text from sutta X" intuition in the docstring.
+QUERIES: list[tuple[str, str]] = [
+    # English paraphrase of the Ānāpānassati suttaverse — should surface MN 118
+    ("mindfulness of breathing", "English paraphrase; expect MN 118 Anāpānassati"),
+    # Pali term with diacritics — dense should handle, sparse should spike
+    ("satipaṭṭhāna", "Pali term with diacritics; expect MN 10 / DN 22"),
+    # Diacritic-free version — matters for user-typed queries
+    ("anapanasati", "ASCII Pali; expect MN 118"),
+    # Core doctrinal question
+    ("four noble truths", "English doctrinal term; expect SN 56.11 Dhammacakka"),
+    # Bare Pali word — sparse signal should dominate
+    ("dukkha", "single-word Pali; expect many suttas"),
+    # Russian query — BGE-M3 is multilingual; dense should cross the bridge
+    ("страдание", "Russian for dukkha; dense cross-lingual test"),
+]
+
+
+def _fmt_text(text: str, width: int = 80) -> str:
+    one_line = " ".join(text.split())
+    if len(one_line) <= width:
+        return one_line
+    return one_line[: width - 1] + "…"
+
+
+async def _text_for_chunks(
+    session_maker: async_sessionmaker,  # type: ignore[type-arg]
+    chunk_ids: list[UUID],
+) -> dict[UUID, str]:
+    if not chunk_ids:
+        return {}
+    async with session_maker() as session:
+        rows = (
+            await session.execute(sa.select(Chunk.id, Chunk.text).where(Chunk.id.in_(chunk_ids)))
+        ).all()
+    return {row.id: row.text for row in rows}
+
+
+async def main() -> int:
+    settings = get_settings()
+    engine = create_async_engine(settings.database_url, future=True, echo=False)
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    client = QdrantClient(url=settings.qdrant_url)
+    encoder = BGEM3Encoder(device="cuda", use_fp16=True)
+
+    print(f"Collection: {COLLECTION_NAME}")
+    count = client.count(COLLECTION_NAME, exact=True).count
+    print(f"Points in collection: {count}")
+    print()
+
+    try:
+        for query, note in QUERIES:
+            encoded = encoder.encode([query])
+            q_dense = encoded.dense[0]
+            q_sparse = encoded.sparse[0]
+
+            dense_hits = client.query_points(
+                collection_name=COLLECTION_NAME,
+                query=q_dense,
+                using=DENSE_VECTOR_NAME,
+                limit=3,
+            ).points
+
+            sparse_indices = [int(k) for k in q_sparse]
+            sparse_values = [float(v) for v in q_sparse.values()]
+            sparse_hits = client.query_points(
+                collection_name=COLLECTION_NAME,
+                query=SparseVector(indices=sparse_indices, values=sparse_values),
+                using=SPARSE_VECTOR_NAME,
+                limit=3,
+            ).points
+
+            all_ids = [UUID(h.id) for h in dense_hits + sparse_hits]
+            texts = await _text_for_chunks(session_maker, all_ids)
+
+            print("=" * 80)
+            print(f"Query:   {query!r}")
+            print(f"Note:    {note}")
+            print("-" * 80)
+            print("DENSE top 3:")
+            for h in dense_hits:
+                uid = UUID(h.id)
+                print(
+                    f"  [{h.score:.3f}] {h.payload['work_canonical_id']:<10} "
+                    f"{h.payload['segment_id'] or '-':<16}"
+                )
+                print(f"      {_fmt_text(texts.get(uid, '<missing>'))}")
+            print("SPARSE top 3:")
+            for h in sparse_hits:
+                uid = UUID(h.id)
+                print(
+                    f"  [{h.score:.3f}] {h.payload['work_canonical_id']:<10} "
+                    f"{h.payload['segment_id'] or '-':<16}"
+                )
+                print(f"      {_fmt_text(texts.get(uid, '<missing>'))}")
+            print()
+    finally:
+        await engine.dispose()
+        client.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/embeddings/indexer.py
+++ b/src/embeddings/indexer.py
@@ -1,0 +1,396 @@
+"""Qdrant indexer — writes BGE-M3 vectors into the ``dharma_v1`` collection.
+
+Role in the stack
+-----------------
+Postgres is the source of truth for text; Qdrant is a *derivative* index
+that must be reproducible from Postgres alone. This module is the only
+thing that writes into Qdrant; anything that reads (retrieval endpoint,
+eval scripts) goes through a separate module in ``src/retrieval/`` that
+lands on day 11.
+
+Collection layout
+-----------------
+Collection name: ``dharma_v1``. The ``v1`` suffix is the embedding-model
+generation, not a code version — when we upgrade the encoder in Phase 2
+we build ``dharma_v2`` alongside, run A/B, then drop the old one. The
+code version (``src.__version__``) is stamped into collection metadata
+for traceability but does not drive the name.
+
+Named vectors per point:
+
+* ``bge_m3_dense`` — 1024-dim cosine-similarity vector (BGE-M3 dense head)
+* ``bge_m3_sparse`` — learned-weight sparse vector (BGE-M3 lexical head)
+
+Payload per point (everything needed for citations and filtering without
+joining back to Postgres on every query):
+
+* ``chunk_id`` — UUID string, duplicates ``point.id`` for non-ID filters
+* ``parent_chunk_id`` — UUID of the parent chunk (or ``None`` for parents
+  themselves, which we don't index by default)
+* ``instance_id`` — UUID of the Instance this chunk belongs to
+* ``work_canonical_id`` — e.g. ``mn10`` — the human-readable citation key
+* ``segment_id`` — e.g. ``mn10:12.3`` — SuttaCentral segment reference
+* ``sequence`` — integer index within the Instance (debugging/citation)
+* ``is_parent`` — redundant with ``parent_chunk_id`` but makes filters
+  trivial (``filter: is_parent == false``)
+* ``token_count`` — cheap to have around for stats / filtering long chunks
+* ``pericope_id`` — optional, for dedup of recurring formulas
+
+Text is NOT in the payload: it lives in Postgres and gets joined back
+server-side when the retrieval endpoint returns citations.
+
+Design
+------
+* **Pure dependency injection.** Both the Qdrant client and the encoder
+  are passed in by the caller (FastAPI startup or CLI). Tests inject
+  in-memory fakes without ever loading the real 2.3 GB BGE-M3 weights or
+  spinning up a Qdrant container.
+* **Batch-level idempotency.** Point IDs are derived from the chunk
+  UUID, so ``upsert`` on the same chunk is a no-op update. Re-running
+  the indexer is safe; interrupted runs can resume.
+* **No implicit reads from Postgres.** The orchestrator takes an
+  ``AsyncIterator[list[ChunkForIndexing]]`` — the CLI wires that up from
+  SQLAlchemy, but a test can feed a hand-crafted list. The indexer does
+  not know what a Session is.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator, Iterable
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+from uuid import UUID
+
+from src.embeddings.bge_m3 import DENSE_DIM, EncodedBatch
+
+logger = logging.getLogger(__name__)
+
+COLLECTION_NAME: str = "dharma_v1"
+DENSE_VECTOR_NAME: str = "bge_m3_dense"
+SPARSE_VECTOR_NAME: str = "bge_m3_sparse"
+
+
+# ---------------------------------------------------------------------------
+# Data shape crossing the indexer boundary
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkForIndexing:
+    """Plain value-object representing one chunk ready to be embedded.
+
+    Decouples the indexer from the SQLAlchemy ORM. The CLI maps from
+    ``Chunk`` + ``Instance`` + ``Expression`` + ``Work`` rows to this
+    shape; unit tests construct it directly.
+    """
+
+    chunk_id: UUID
+    text: str
+    parent_chunk_id: UUID | None
+    instance_id: UUID
+    work_canonical_id: str
+    segment_id: str | None
+    sequence: int
+    is_parent: bool
+    token_count: int
+    pericope_id: str | None = None
+
+
+@dataclass(slots=True)
+class IndexerStats:
+    """Running counters for a single ``index_corpus`` invocation.
+
+    Mutable because the orchestrator accumulates as it streams batches;
+    callers treat it as read-only after ``index_corpus`` returns.
+    """
+
+    batches_processed: int = 0
+    chunks_encoded: int = 0
+    points_upserted: int = 0
+    skipped_empty: int = 0
+    # Batch IDs that failed to upsert — the orchestrator continues past
+    # transient errors so one bad batch does not lose 9,000 good ones.
+    failed_batches: list[int] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Protocols for DI (we duck-type the real clients so tests run bare)
+# ---------------------------------------------------------------------------
+
+
+class EncoderProtocol(Protocol):
+    """Subset of :class:`src.embeddings.bge_m3.BGEM3Encoder` we use.
+
+    Declaring a Protocol rather than importing the concrete class lets
+    the test suite inject a fake that does not need torch at all.
+    """
+
+    def encode(
+        self,
+        texts: list[str],
+        *,
+        batch_size: int = ...,
+        max_length: int = ...,
+    ) -> EncodedBatch: ...
+
+
+class QdrantClientProtocol(Protocol):
+    """Structural type matching the slice of ``qdrant_client.QdrantClient``
+    we actually call. Covers both the sync and thin-async wrapper.
+
+    We accept the untyped ``Any`` for model arguments because the real
+    ``qdrant_client.models`` classes are pydantic models and importing
+    them here would drag the entire client into every test module.
+    """
+
+    def collection_exists(self, collection_name: str) -> bool: ...
+
+    def create_collection(
+        self,
+        collection_name: str,
+        vectors_config: Any,
+        sparse_vectors_config: Any,
+        **kwargs: Any,
+    ) -> Any: ...
+
+    def delete_collection(self, collection_name: str) -> Any: ...
+
+    def upsert(
+        self,
+        collection_name: str,
+        points: list[Any],
+        **kwargs: Any,
+    ) -> Any: ...
+
+    def count(self, collection_name: str, exact: bool = ...) -> Any: ...
+
+
+# ---------------------------------------------------------------------------
+# Collection management
+# ---------------------------------------------------------------------------
+
+
+def ensure_collection(
+    client: QdrantClientProtocol,
+    *,
+    collection_name: str = COLLECTION_NAME,
+    dense_dim: int = DENSE_DIM,
+    recreate: bool = False,
+) -> bool:
+    """Create the collection if it is missing (or recreate on demand).
+
+    Returns ``True`` if a collection was created (or recreated),
+    ``False`` if it already existed and was left alone. The boolean is
+    handy for the CLI to print a one-line status and for tests to
+    assert on a fresh-vs-existing branch.
+
+    ``recreate=True`` drops the existing collection first. Use it for
+    schema changes — e.g. adding a new named vector — where the payload
+    format itself is incompatible. Outside of those cases, prefer
+    idempotent upserts over recreation.
+    """
+    from qdrant_client.models import (  # noqa: PLC0415 — defer heavy import
+        Distance,
+        SparseVectorParams,
+        VectorParams,
+    )
+
+    exists = client.collection_exists(collection_name)
+    if exists and not recreate:
+        logger.info("Collection %r already exists; skipping create.", collection_name)
+        return False
+    if exists and recreate:
+        logger.warning("Recreating collection %r (--recreate).", collection_name)
+        client.delete_collection(collection_name)
+
+    client.create_collection(
+        collection_name=collection_name,
+        # Cosine is the standard for normalised sentence embeddings;
+        # BGE-M3 already L2-normalises dense outputs internally, so
+        # cosine and dot-product give identical rankings — we keep
+        # cosine because Qdrant's UI and metrics treat it as default.
+        vectors_config={
+            DENSE_VECTOR_NAME: VectorParams(size=dense_dim, distance=Distance.COSINE),
+        },
+        sparse_vectors_config={
+            SPARSE_VECTOR_NAME: SparseVectorParams(),
+        },
+    )
+    logger.info("Collection %r created (dense=%dd cosine, sparse=1).", collection_name, dense_dim)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Point construction
+# ---------------------------------------------------------------------------
+
+
+def build_point(chunk: ChunkForIndexing, dense: list[float], sparse: dict[str, float]) -> Any:
+    """Assemble a Qdrant ``PointStruct`` for one chunk.
+
+    Split out as a pure function so tests can assert on the exact
+    payload shape without spinning up a Qdrant client, and so the
+    orchestrator stays small.
+
+    ``sparse`` arrives as ``{token_id_str: weight}`` — BGE-M3 emits
+    keys as strings (FlagEmbedding's convention). Qdrant's
+    ``SparseVector`` wants parallel int indices + float values, so we
+    convert here. Empty sparse maps are valid: BGE-M3 produces them on
+    rare-token-only inputs.
+    """
+    from qdrant_client.models import PointStruct, SparseVector  # noqa: PLC0415
+
+    indices: list[int] = []
+    values: list[float] = []
+    for token_id_str, weight in sparse.items():
+        indices.append(int(token_id_str))
+        values.append(float(weight))
+
+    payload: dict[str, Any] = {
+        "chunk_id": str(chunk.chunk_id),
+        "parent_chunk_id": str(chunk.parent_chunk_id) if chunk.parent_chunk_id else None,
+        "instance_id": str(chunk.instance_id),
+        "work_canonical_id": chunk.work_canonical_id,
+        "segment_id": chunk.segment_id,
+        "sequence": chunk.sequence,
+        "is_parent": chunk.is_parent,
+        "token_count": chunk.token_count,
+    }
+    if chunk.pericope_id is not None:
+        payload["pericope_id"] = chunk.pericope_id
+
+    return PointStruct(
+        id=str(chunk.chunk_id),
+        vector={
+            DENSE_VECTOR_NAME: dense,
+            SPARSE_VECTOR_NAME: SparseVector(indices=indices, values=values),
+        },
+        payload=payload,
+    )
+
+
+def build_points(
+    chunks: list[ChunkForIndexing],
+    encoded: EncodedBatch,
+) -> list[Any]:
+    """Zip a chunk batch with its encoded vectors into Qdrant points.
+
+    The encoder contract guarantees ``len(chunks) == len(dense) ==
+    len(sparse)`` — we still assert that here because silent misalignment
+    between text and vector is the worst class of bug in a RAG pipeline
+    (the retrieval still returns something plausible, just wrong).
+    """
+    if len(chunks) != len(encoded.dense) or len(chunks) != len(encoded.sparse):
+        raise RuntimeError(
+            "Misaligned batch: "
+            f"{len(chunks)} chunks, {len(encoded.dense)} dense, "
+            f"{len(encoded.sparse)} sparse."
+        )
+    return [
+        build_point(chunk, dense, sparse)
+        for chunk, dense, sparse in zip(chunks, encoded.dense, encoded.sparse, strict=True)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+async def index_corpus(
+    *,
+    client: QdrantClientProtocol,
+    encoder: EncoderProtocol,
+    batches: AsyncIterator[list[ChunkForIndexing]],
+    collection_name: str = COLLECTION_NAME,
+    encoder_batch_size: int = 12,
+    encoder_max_length: int = 2048,
+    continue_on_error: bool = True,
+) -> IndexerStats:
+    """Stream chunk batches through encoder → Qdrant, accumulate stats.
+
+    The caller is responsible for:
+
+    * Making the collection exist (``ensure_collection`` on the same
+      ``client``).
+    * Producing ``batches`` — typically pulled from Postgres in
+      ``batch_size``-sized chunks, but the indexer doesn't care.
+
+    On per-batch errors: we log and continue when ``continue_on_error``
+    is True (the common case for a 10k-point run) so a flaky point
+    doesn't lose the rest. Batch indices of failures are captured in
+    ``IndexerStats.failed_batches``; the CLI prints them at the end and
+    exits non-zero if the list is non-empty.
+    """
+    stats = IndexerStats()
+
+    async for batch in batches:
+        batch_index = stats.batches_processed
+        stats.batches_processed += 1
+        if not batch:
+            stats.skipped_empty += 1
+            continue
+
+        texts = [c.text for c in batch]
+        try:
+            encoded = encoder.encode(
+                texts,
+                batch_size=encoder_batch_size,
+                max_length=encoder_max_length,
+            )
+        except Exception as exc:  # noqa: BLE001 — orchestrator must keep going
+            logger.exception(
+                "Encoder failed on batch %d (%d chunks): %s", batch_index, len(batch), exc
+            )
+            stats.failed_batches.append(batch_index)
+            if not continue_on_error:
+                raise
+            continue
+
+        stats.chunks_encoded += len(batch)
+
+        try:
+            points = build_points(batch, encoded)
+            client.upsert(collection_name=collection_name, points=points)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Qdrant upsert failed on batch %d: %s", batch_index, exc)
+            stats.failed_batches.append(batch_index)
+            if not continue_on_error:
+                raise
+            continue
+
+        stats.points_upserted += len(batch)
+        if stats.batches_processed % 10 == 0:
+            logger.info(
+                "Indexed %d chunks across %d batches (failed: %d)",
+                stats.points_upserted,
+                stats.batches_processed,
+                len(stats.failed_batches),
+            )
+
+    logger.info(
+        "Indexing complete: %d chunks upserted in %d batches (empty: %d, failed: %d)",
+        stats.points_upserted,
+        stats.batches_processed,
+        stats.skipped_empty,
+        len(stats.failed_batches),
+    )
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Convenience: synchronous iterable → async batches adapter
+# ---------------------------------------------------------------------------
+
+
+async def batches_from_iterable(
+    source: Iterable[list[ChunkForIndexing]],
+) -> AsyncIterator[list[ChunkForIndexing]]:
+    """Adapt a plain sync iterable of batches to the async contract.
+
+    Makes tests straightforward: the caller builds a list of batches
+    in a fixture and wraps it here without touching asyncio.
+    """
+    for batch in source:
+        yield batch

--- a/tests/integration/test_qdrant_indexer.py
+++ b/tests/integration/test_qdrant_indexer.py
@@ -1,0 +1,232 @@
+"""Integration tests for the Qdrant indexer against a live Qdrant.
+
+These tests verify that the PointStruct shape we build is actually
+accepted by the real qdrant-client, that named vectors round-trip,
+and that vector search on dense + sparse retrieves the expected points.
+
+They are skipped automatically when Qdrant is unreachable — no docker,
+no tests, no noise.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from uuid import uuid4
+
+import pytest
+
+from src.embeddings.bge_m3 import DENSE_DIM, EncodedBatch
+from src.embeddings.indexer import (
+    DENSE_VECTOR_NAME,
+    SPARSE_VECTOR_NAME,
+    ChunkForIndexing,
+    build_points,
+    ensure_collection,
+)
+
+pytestmark = pytest.mark.integration
+
+QDRANT_URL = os.environ.get("QDRANT_URL", "http://localhost:6333")
+
+
+def _qdrant_available() -> bool:
+    """Return True if we can reach Qdrant on QDRANT_URL."""
+    try:
+        from qdrant_client import QdrantClient  # noqa: PLC0415
+    except ImportError:
+        return False
+    try:
+        client = QdrantClient(url=QDRANT_URL, timeout=2)
+        client.get_collections()
+    except Exception:
+        return False
+    return True
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(not _qdrant_available(), reason=f"Qdrant is not reachable at {QDRANT_URL}"),
+]
+
+
+@pytest.fixture
+def test_collection() -> Iterator[str]:
+    """Yield a fresh, uniquely-named collection and drop it on teardown."""
+    from qdrant_client import QdrantClient  # noqa: PLC0415
+
+    name = f"dharma_test_{uuid4().hex[:8]}"
+    client = QdrantClient(url=QDRANT_URL)
+    try:
+        yield name
+    finally:
+        try:
+            if client.collection_exists(name):
+                client.delete_collection(name)
+        finally:
+            client.close()
+
+
+def _small_chunk(text: str) -> ChunkForIndexing:
+    return ChunkForIndexing(
+        chunk_id=uuid4(),
+        text=text,
+        parent_chunk_id=None,
+        instance_id=uuid4(),
+        work_canonical_id="test1",
+        segment_id="test1:0.1",
+        sequence=0,
+        is_parent=False,
+        token_count=len(text.split()),
+    )
+
+
+def test_ensure_collection_creates_real_collection(test_collection: str) -> None:
+    from qdrant_client import QdrantClient  # noqa: PLC0415
+
+    client = QdrantClient(url=QDRANT_URL)
+    try:
+        created = ensure_collection(client, collection_name=test_collection)
+        assert created is True
+        info = client.get_collection(test_collection)
+        # Named vectors structure check — presence is what we care about.
+        vec_params = info.config.params.vectors
+        assert DENSE_VECTOR_NAME in vec_params
+        assert vec_params[DENSE_VECTOR_NAME].size == DENSE_DIM
+        sparse_params = info.config.params.sparse_vectors
+        assert sparse_params is not None
+        assert SPARSE_VECTOR_NAME in sparse_params
+    finally:
+        client.close()
+
+
+def test_upsert_and_retrieve_by_id(test_collection: str) -> None:
+    """Build real PointStructs, upsert them, then retrieve by point ID."""
+    from qdrant_client import QdrantClient  # noqa: PLC0415
+
+    client = QdrantClient(url=QDRANT_URL)
+    try:
+        ensure_collection(client, collection_name=test_collection)
+
+        chunks = [_small_chunk("sati means mindfulness"), _small_chunk("dukkha is suffering")]
+        encoded = EncodedBatch(
+            dense=[[0.1] * DENSE_DIM, [0.2] * DENSE_DIM],
+            sparse=[{"1": 0.5, "2": 0.3}, {"3": 0.9}],
+        )
+        points = build_points(chunks, encoded)
+        client.upsert(collection_name=test_collection, points=points)
+
+        ids = [str(c.chunk_id) for c in chunks]
+        retrieved = client.retrieve(
+            collection_name=test_collection, ids=ids, with_payload=True, with_vectors=True
+        )
+        assert len(retrieved) == 2
+        by_id = {r.id: r for r in retrieved}
+        for chunk in chunks:
+            row = by_id[str(chunk.chunk_id)]
+            assert row.payload["work_canonical_id"] == "test1"
+            assert row.payload["chunk_id"] == str(chunk.chunk_id)
+            assert DENSE_VECTOR_NAME in row.vector
+            assert SPARSE_VECTOR_NAME in row.vector
+    finally:
+        client.close()
+
+
+def test_dense_search_ranks_closer_vector_first(test_collection: str) -> None:
+    """Semantic search plumbing: a query vector close to point A should
+    rank A above B.
+    """
+    from qdrant_client import QdrantClient  # noqa: PLC0415
+
+    client = QdrantClient(url=QDRANT_URL)
+    try:
+        ensure_collection(client, collection_name=test_collection)
+
+        chunk_a = _small_chunk("close point")
+        chunk_b = _small_chunk("far point")
+        # Distinct dense vectors. a is pointing along axis 0, b along axis 1.
+        vec_a = [1.0] + [0.0] * (DENSE_DIM - 1)
+        vec_b = [0.0] + [1.0] + [0.0] * (DENSE_DIM - 2)
+        encoded = EncodedBatch(dense=[vec_a, vec_b], sparse=[{}, {}])
+        client.upsert(
+            collection_name=test_collection,
+            points=build_points([chunk_a, chunk_b], encoded),
+        )
+
+        # A query vector identical to A's embedding should retrieve A
+        # with cosine similarity 1.0 and rank it first.
+        result = client.query_points(
+            collection_name=test_collection,
+            query=vec_a,
+            using=DENSE_VECTOR_NAME,
+            limit=2,
+        )
+        hits = result.points
+        assert len(hits) == 2
+        assert hits[0].id == str(chunk_a.chunk_id)
+        assert hits[0].score == pytest.approx(1.0, abs=1e-4)
+        assert hits[1].id == str(chunk_b.chunk_id)
+        assert hits[0].score > hits[1].score
+    finally:
+        client.close()
+
+
+def test_sparse_search_rates_matching_tokens_higher(test_collection: str) -> None:
+    """Sparse vectors: a query that shares a strongly-weighted token
+    should retrieve the point that has that token.
+    """
+    from qdrant_client import QdrantClient  # noqa: PLC0415
+    from qdrant_client.models import SparseVector  # noqa: PLC0415
+
+    client = QdrantClient(url=QDRANT_URL)
+    try:
+        ensure_collection(client, collection_name=test_collection)
+
+        chunk_sati = _small_chunk("sati")
+        chunk_dukkha = _small_chunk("dukkha")
+        # Token id 111 represents "sati"; 222 represents "dukkha"
+        encoded = EncodedBatch(
+            dense=[[0.0] * DENSE_DIM, [0.0] * DENSE_DIM],
+            sparse=[{"111": 0.9}, {"222": 0.9}],
+        )
+        client.upsert(
+            collection_name=test_collection,
+            points=build_points([chunk_sati, chunk_dukkha], encoded),
+        )
+
+        result = client.query_points(
+            collection_name=test_collection,
+            query=SparseVector(indices=[111], values=[1.0]),
+            using=SPARSE_VECTOR_NAME,
+            limit=2,
+        )
+        hits = result.points
+        # Only the sati point should surface — dukkha has no token 111.
+        assert hits
+        assert hits[0].id == str(chunk_sati.chunk_id)
+    finally:
+        client.close()
+
+
+def test_upsert_is_idempotent(test_collection: str) -> None:
+    """Re-upserting the same chunk UUID is a no-op on count."""
+    from qdrant_client import QdrantClient  # noqa: PLC0415
+
+    client = QdrantClient(url=QDRANT_URL)
+    try:
+        ensure_collection(client, collection_name=test_collection)
+
+        chunk = _small_chunk("idempotency check")
+        encoded = EncodedBatch(dense=[[0.3] * DENSE_DIM], sparse=[{}])
+        points = build_points([chunk], encoded)
+
+        client.upsert(collection_name=test_collection, points=points)
+        first_count = client.count(test_collection, exact=True).count
+
+        client.upsert(collection_name=test_collection, points=points)
+        second_count = client.count(test_collection, exact=True).count
+
+        assert first_count == 1
+        assert second_count == 1
+    finally:
+        client.close()

--- a/tests/unit/embeddings/test_indexer.py
+++ b/tests/unit/embeddings/test_indexer.py
@@ -1,0 +1,401 @@
+"""Unit tests for the Qdrant indexer.
+
+No real Qdrant, no real BGE-M3 — every test injects a ``FakeQdrantClient``
+and ``FakeEncoder`` so the suite runs in under a second with no network
+or GPU.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.embeddings.bge_m3 import DENSE_DIM, EncodedBatch
+from src.embeddings.indexer import (
+    COLLECTION_NAME,
+    DENSE_VECTOR_NAME,
+    SPARSE_VECTOR_NAME,
+    ChunkForIndexing,
+    IndexerStats,
+    batches_from_iterable,
+    build_point,
+    build_points,
+    ensure_collection,
+    index_corpus,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeQdrantClient:
+    """Records every client call so tests can assert on sequence + args."""
+
+    existing_collections: set[str] = field(default_factory=set)
+    created: list[dict[str, Any]] = field(default_factory=list)
+    deleted: list[str] = field(default_factory=list)
+    upserts: list[dict[str, Any]] = field(default_factory=list)
+    upsert_fail_on_batch_index: int | None = None
+    _upsert_calls: int = 0
+
+    def collection_exists(self, collection_name: str) -> bool:
+        return collection_name in self.existing_collections
+
+    def create_collection(
+        self,
+        collection_name: str,
+        vectors_config: Any,
+        sparse_vectors_config: Any,
+        **kwargs: Any,
+    ) -> None:
+        self.created.append(
+            {
+                "collection_name": collection_name,
+                "vectors_config": vectors_config,
+                "sparse_vectors_config": sparse_vectors_config,
+                "kwargs": kwargs,
+            }
+        )
+        self.existing_collections.add(collection_name)
+
+    def delete_collection(self, collection_name: str) -> None:
+        self.deleted.append(collection_name)
+        self.existing_collections.discard(collection_name)
+
+    def upsert(
+        self,
+        collection_name: str,
+        points: list[Any],
+        **kwargs: Any,
+    ) -> None:
+        if (
+            self.upsert_fail_on_batch_index is not None
+            and self._upsert_calls == self.upsert_fail_on_batch_index
+        ):
+            self._upsert_calls += 1
+            raise RuntimeError("simulated upsert failure")
+        self._upsert_calls += 1
+        self.upserts.append(
+            {
+                "collection_name": collection_name,
+                "points": points,
+                "kwargs": kwargs,
+            }
+        )
+
+    def count(self, collection_name: str, exact: bool = True) -> int:
+        return sum(
+            len(u["points"]) for u in self.upserts if u["collection_name"] == collection_name
+        )
+
+
+class FakeEncoder:
+    """Deterministic stand-in for :class:`BGEM3Encoder`."""
+
+    def __init__(self, *, fail_on_call: int | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.fail_on_call = fail_on_call
+
+    def encode(
+        self,
+        texts: list[str],
+        *,
+        batch_size: int = 12,
+        max_length: int = 2048,
+    ) -> EncodedBatch:
+        self.calls.append(
+            {"texts": list(texts), "batch_size": batch_size, "max_length": max_length}
+        )
+        if self.fail_on_call is not None and len(self.calls) - 1 == self.fail_on_call:
+            raise RuntimeError("simulated encoder failure")
+        dense = [[float(i)] * DENSE_DIM for i in range(len(texts))]
+        sparse = [{"42": 0.5 + i * 0.01, "7": 0.3} for i in range(len(texts))]
+        return EncodedBatch(dense=dense, sparse=sparse)
+
+
+def _sample_chunk(
+    *,
+    chunk_id: UUID | None = None,
+    parent_chunk_id: UUID | None = None,
+    text: str = "hello world",
+    is_parent: bool = False,
+    pericope_id: str | None = None,
+) -> ChunkForIndexing:
+    return ChunkForIndexing(
+        chunk_id=chunk_id or uuid4(),
+        text=text,
+        parent_chunk_id=parent_chunk_id,
+        instance_id=uuid4(),
+        work_canonical_id="mn10",
+        segment_id="mn10:12.3",
+        sequence=7,
+        is_parent=is_parent,
+        token_count=42,
+        pericope_id=pericope_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ensure_collection
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_collection_creates_when_missing() -> None:
+    client = FakeQdrantClient()
+    created = ensure_collection(client)
+    assert created is True
+    assert len(client.created) == 1
+    cfg = client.created[0]
+    assert cfg["collection_name"] == COLLECTION_NAME
+    assert DENSE_VECTOR_NAME in cfg["vectors_config"]
+    assert SPARSE_VECTOR_NAME in cfg["sparse_vectors_config"]
+    assert cfg["vectors_config"][DENSE_VECTOR_NAME].size == DENSE_DIM
+
+
+def test_ensure_collection_is_noop_when_already_exists() -> None:
+    client = FakeQdrantClient(existing_collections={COLLECTION_NAME})
+    created = ensure_collection(client)
+    assert created is False
+    assert client.created == []
+    assert client.deleted == []
+
+
+def test_ensure_collection_recreates_when_requested() -> None:
+    client = FakeQdrantClient(existing_collections={COLLECTION_NAME})
+    created = ensure_collection(client, recreate=True)
+    assert created is True
+    assert client.deleted == [COLLECTION_NAME]
+    assert len(client.created) == 1
+
+
+def test_ensure_collection_respects_custom_dim() -> None:
+    client = FakeQdrantClient()
+    ensure_collection(client, dense_dim=384)
+    assert client.created[0]["vectors_config"][DENSE_VECTOR_NAME].size == 384
+
+
+# ---------------------------------------------------------------------------
+# build_point / build_points
+# ---------------------------------------------------------------------------
+
+
+def test_build_point_payload_covers_required_fields() -> None:
+    chunk = _sample_chunk()
+    dense = [0.1] * DENSE_DIM
+    sparse = {"42": 0.8, "7": 0.2}
+
+    point = build_point(chunk, dense, sparse)
+
+    assert point.id == str(chunk.chunk_id)
+    assert point.payload["chunk_id"] == str(chunk.chunk_id)
+    assert point.payload["instance_id"] == str(chunk.instance_id)
+    assert point.payload["work_canonical_id"] == "mn10"
+    assert point.payload["segment_id"] == "mn10:12.3"
+    assert point.payload["sequence"] == 7
+    assert point.payload["is_parent"] is False
+    assert point.payload["token_count"] == 42
+    assert point.payload["parent_chunk_id"] is None
+
+
+def test_build_point_includes_pericope_id_when_set() -> None:
+    chunk = _sample_chunk(pericope_id="jhana-formula-1")
+    point = build_point(chunk, [0.0] * DENSE_DIM, {})
+    assert point.payload["pericope_id"] == "jhana-formula-1"
+
+
+def test_build_point_omits_pericope_id_when_none() -> None:
+    chunk = _sample_chunk()
+    point = build_point(chunk, [0.0] * DENSE_DIM, {})
+    assert "pericope_id" not in point.payload
+
+
+def test_build_point_serialises_parent_chunk_id_as_string() -> None:
+    parent_id = uuid4()
+    chunk = _sample_chunk(parent_chunk_id=parent_id)
+    point = build_point(chunk, [0.0] * DENSE_DIM, {})
+    assert point.payload["parent_chunk_id"] == str(parent_id)
+
+
+def test_build_point_vectors_carry_named_keys() -> None:
+    chunk = _sample_chunk()
+    dense = [0.5] * DENSE_DIM
+    sparse = {"100": 1.5, "200": 0.25}
+
+    point = build_point(chunk, dense, sparse)
+
+    assert DENSE_VECTOR_NAME in point.vector
+    assert SPARSE_VECTOR_NAME in point.vector
+    assert point.vector[DENSE_VECTOR_NAME] == dense
+    sv = point.vector[SPARSE_VECTOR_NAME]
+    # indices/values are parallel arrays; order of dict keys is preserved
+    # on CPython 3.7+, so this assertion is deterministic.
+    assert sv.indices == [100, 200]
+    assert sv.values == [1.5, 0.25]
+
+
+def test_build_point_accepts_empty_sparse() -> None:
+    chunk = _sample_chunk()
+    point = build_point(chunk, [0.0] * DENSE_DIM, {})
+    sv = point.vector[SPARSE_VECTOR_NAME]
+    assert sv.indices == []
+    assert sv.values == []
+
+
+def test_build_points_zips_batch_correctly() -> None:
+    chunks = [_sample_chunk(text=f"c{i}") for i in range(3)]
+    dense = [[float(i)] * DENSE_DIM for i in range(3)]
+    sparse: list[dict[str, float]] = [{"1": 0.1}, {"2": 0.2}, {"3": 0.3}]
+    encoded = EncodedBatch(dense=dense, sparse=sparse)
+
+    points = build_points(chunks, encoded)
+
+    assert len(points) == 3
+    for i, point in enumerate(points):
+        assert point.id == str(chunks[i].chunk_id)
+        assert point.vector[DENSE_VECTOR_NAME] == dense[i]
+        expected_idx = [int(k) for k in sparse[i].keys()]
+        assert points[i].vector[SPARSE_VECTOR_NAME].indices == expected_idx
+
+
+def test_build_points_raises_on_misaligned_batch() -> None:
+    chunks = [_sample_chunk() for _ in range(3)]
+    encoded = EncodedBatch(dense=[[0.0] * DENSE_DIM, [0.0] * DENSE_DIM], sparse=[{}, {}])
+    with pytest.raises(RuntimeError, match="Misaligned batch"):
+        build_points(chunks, encoded)
+
+
+# ---------------------------------------------------------------------------
+# index_corpus orchestration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_index_corpus_happy_path() -> None:
+    client = FakeQdrantClient(existing_collections={COLLECTION_NAME})
+    encoder = FakeEncoder()
+
+    batch1 = [_sample_chunk(text=f"a{i}") for i in range(3)]
+    batch2 = [_sample_chunk(text=f"b{i}") for i in range(2)]
+
+    stats = await index_corpus(
+        client=client,
+        encoder=encoder,
+        batches=batches_from_iterable([batch1, batch2]),
+    )
+
+    assert stats.batches_processed == 2
+    assert stats.chunks_encoded == 5
+    assert stats.points_upserted == 5
+    assert stats.failed_batches == []
+    assert len(client.upserts) == 2
+    assert len(client.upserts[0]["points"]) == 3
+    assert len(client.upserts[1]["points"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_index_corpus_skips_empty_batches() -> None:
+    client = FakeQdrantClient(existing_collections={COLLECTION_NAME})
+    encoder = FakeEncoder()
+    real_chunk = _sample_chunk(text="real")
+
+    stats = await index_corpus(
+        client=client,
+        encoder=encoder,
+        batches=batches_from_iterable([[], [real_chunk], []]),
+    )
+
+    assert stats.skipped_empty == 2
+    assert stats.points_upserted == 1
+    # Encoder must have been invoked only for the non-empty batch.
+    assert len(encoder.calls) == 1
+    assert encoder.calls[0]["texts"] == ["real"]
+
+
+@pytest.mark.asyncio
+async def test_index_corpus_records_encoder_failure_and_continues() -> None:
+    client = FakeQdrantClient(existing_collections={COLLECTION_NAME})
+    encoder = FakeEncoder(fail_on_call=0)  # first batch fails
+
+    batch_good = [_sample_chunk(text="good")]
+    batch_also_good = [_sample_chunk(text="also")]
+
+    stats = await index_corpus(
+        client=client,
+        encoder=encoder,
+        batches=batches_from_iterable([batch_good, batch_also_good]),
+    )
+
+    assert stats.batches_processed == 2
+    assert stats.failed_batches == [0]
+    assert stats.points_upserted == 1
+    assert len(client.upserts) == 1
+    assert client.upserts[0]["points"][0].payload["chunk_id"] == str(batch_also_good[0].chunk_id)
+
+
+@pytest.mark.asyncio
+async def test_index_corpus_records_upsert_failure_and_continues() -> None:
+    client = FakeQdrantClient(existing_collections={COLLECTION_NAME}, upsert_fail_on_batch_index=0)
+    encoder = FakeEncoder()
+
+    stats = await index_corpus(
+        client=client,
+        encoder=encoder,
+        batches=batches_from_iterable([[_sample_chunk()], [_sample_chunk()]]),
+    )
+
+    assert stats.failed_batches == [0]
+    assert stats.points_upserted == 1
+    # Encoder still ran on the failed batch (failure is at upsert stage)
+    assert len(encoder.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_index_corpus_propagates_when_continue_on_error_false() -> None:
+    client = FakeQdrantClient(existing_collections={COLLECTION_NAME})
+    encoder = FakeEncoder(fail_on_call=0)
+
+    with pytest.raises(RuntimeError, match="simulated encoder failure"):
+        await index_corpus(
+            client=client,
+            encoder=encoder,
+            batches=batches_from_iterable([[_sample_chunk()]]),
+            continue_on_error=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_index_corpus_passes_encoder_tuning() -> None:
+    client = FakeQdrantClient(existing_collections={COLLECTION_NAME})
+    encoder = FakeEncoder()
+
+    await index_corpus(
+        client=client,
+        encoder=encoder,
+        batches=batches_from_iterable([[_sample_chunk()]]),
+        encoder_batch_size=64,
+        encoder_max_length=512,
+    )
+
+    assert encoder.calls[0]["batch_size"] == 64
+    assert encoder.calls[0]["max_length"] == 512
+
+
+@pytest.mark.asyncio
+async def test_index_corpus_empty_stream_is_a_noop() -> None:
+    client = FakeQdrantClient(existing_collections={COLLECTION_NAME})
+    encoder = FakeEncoder()
+
+    stats = await index_corpus(
+        client=client,
+        encoder=encoder,
+        batches=batches_from_iterable([]),
+    )
+
+    assert stats == IndexerStats()
+    assert client.upserts == []
+    assert encoder.calls == []


### PR DESCRIPTION
## Summary

Completes rag-day-10: the BGE-M3 vectors for the entire corpus live in Qdrant's `dharma_v1` collection, and a qualitative retrieval smoke-test confirms the pipeline is semantically meaningful end-to-end.

- **Indexer module** (`src/embeddings/indexer.py`): DI-first, `QdrantClientProtocol` + `EncoderProtocol`, named vectors `bge_m3_dense` (1024d cosine) + `bge_m3_sparse`, continue-on-error orchestration with `IndexerStats`. 98% coverage, 19 unit tests.
- **Integration tests** (5): real qdrant-client 1.17 accepts our `PointStruct`, `query_points` round-trips dense/sparse, cosine=1.0 on identity vector, upsert is idempotent.
- **CLI** `scripts/index_qdrant.py`: keyset-paginated Postgres stream → BGE-M3 → Qdrant upsert. Flags: `--limit`, `--recreate`, `--include-parents`, `--device`, `--use-fp16`.
- **Smoke** `scripts/smoke_retrieval.py`: 6 canonical queries (EN / Pali / RU), dense + sparse top-3 each.

## Indexing run

- **6,478 child chunks** indexed in **4:40 min** on GTX 1080 Ti (fp16)
- ~23 chunks/sec, **0 failed batches**
- Collection size after run: 6478 ✓

## Retrieval quality (qualitative baseline, pre-reranker)

| Query | Top dense hit | Score | Verdict |
|---|---|---|---|
| `mindfulness of breathing` | **MN 118** (Anāpānassati) | 0.700 | 🟢 |
| `four noble truths` | **SN 56.27** (Noble Truths) | 0.714 | 🟢 |
| `страдание` (RU) | **DN 22** (Mahāsatipaṭṭhāna) | 0.624 | 🟢 cross-lingual works |
| `satipaṭṭhāna` (Pali) | SN 55.26 / DN 24 / MN 78 | 0.49 | 🔴 does not land on MN 10 |
| `anapanasati` (ASCII) | AN 8.51 / SN 28.9 / AN 10.75 | 0.45 | 🔴 does not land on MN 118 |
| `dukkha` (Pali) | AN 8.8 / MN 50 / SN 35.134 | 0.45 | 🟡 |

Bare Pali terms without reranker is the known gap — that's exactly what days 11 (hybrid fusion), 12 (Contextual Retrieval), and 13 (BGE-reranker-v2-m3) address. The numeric gate lives on day 14 (Ragas + golden set).

## Toolchain bumps (forced by day-10)

Two latent day-8 conflicts that finally bit:
- torch 2.5.1+cu121 → **2.6.0+cu124** (CVE-2025-32434: transformers 4.57 blocks pickle checkpoint load on torch<2.6; BGE-M3 upstream is .bin, not safetensors)
- huggingface-hub 1.11 → **0.36** (transformers 4.x requires <1.0)

## Test plan

- [x] `pytest tests/unit tests/integration` — 131 passing (no regressions from day-9)
- [x] Smoke indexing run `--limit 100 --recreate` → 100 points upserted, 0 failures
- [x] Full corpus run `--recreate` → 6478 points, 0 failures
- [x] `scripts/smoke_retrieval.py` exercises 6 canonical queries end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)