### PR TITLE
rag-day-21: v0.1.0 release — Phase 1 Foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,27 @@
 
 ## [Unreleased]
 
+_(no unreleased changes yet — next entries will land here on `dev`.)_
+
+---
+
+## [0.1.0] — 2026-04-28 — Phase 1 Foundation
+
+End of Phase 1. Closes the 21-day plan: SuttaCentral corpus → Postgres FRBR → hybrid retrieval (BGE-M3 dense + sparse + Postgres BM25, RRF fusion) → Contextual Retrieval (`dharma_v2` collection via OpenRouter/Haiku 3.5) → parent/child small-to-big expansion → stable `POST /api/query` contract → integration-level docs (`ARCHITECTURE.md` + `RAG_PIPELINE.md`).
+
+**Headline numbers** (synthetic golden v0.0, n=30 — directional only, NOT authoritative pending B-001 buddhologist set):
+- `ref_hit@5` = **0.567** (production: `dharma_v2` + `rerank=False` + `expand_parents=True`)
+- `ref_hit@20` = 0.767 — improvement of +16.7 pp on each over the day-13 baseline (`dharma_v1` + rerank)
+- `MRR` = 0.368 (vs 0.244 baseline)
+- Latency: ~80 ms/query end-to-end on GTX 1080 Ti (encode 50% / channels 30% / enrich 12% / RRF + service post-processing 8%)
+
+**Surface delivered**: `POST /api/query` (frozen public contract, day 19), `POST /api/retrieve` (internal diagnostic surface), `/health`. LLM generation deliberately **not** in scope — Phase 2 (day 22+).
+
+**Phase 1 gate** (per plan): `ref_hit@5 ≥ 0.60`. Synthetic v0.0 hit 0.567 — within noise of target on n=30; authoritative judgement deferred until B-001 is unblocked.
+
 ### Added
+- **rag-day-21:** v0.1.0 release. `__version__` and `pyproject.toml` bumped 0.0.3 → 0.1.0. `docs/RELEASE_v0.1.0.md` published. Closes the 21-day Phase 1 plan.
+
 - **rag-day-20:** Integration-level documentation. `docs/ARCHITECTURE.md` is the single-page system overview: module-by-module responsibility map across `src/{api,rag,retrieval,embeddings,db,ingest,processing,contextual,eval,observability}`, ingest data flow (SuttaCentral → Postgres FRBR → BGE-M3 → Qdrant `dharma_v2`), query data flow (one-line summary of the 5-stage pipeline), storage / external deps tables, and inter-module dependency rules (`api→rag→retrieval→embeddings/db`). `docs/RAG_PIPELINE.md` is the runtime trace: a canonical `POST /api/query` request stepped through with mermaid sequence + component diagrams, per-stage spans (`hybrid.encode`, `hybrid.channels`, `hybrid.rrf`, `hybrid.enrich`, `hybrid.rerank`) with code references, latency breakdown (~78 ms total, dominated by encode + channels), Phoenix span tree, failure-mode table (cold start, missing migration 003, reranker accidentally on, etc.). These two docs sit above the per-concept files in `docs/concepts/` so a new contributor (or future-self after 3 months) can read one page instead of 13. No code changes; 285 unit tests still green; mypy strict + ruff clean.
 
 - **rag-day-19:** `POST /api/query` — stable production retrieval endpoint with frozen contract. New `src/rag/` module: `schemas.py` (`QueryRequest`/`QueryResponse`/`Source`/`PipelineMetadata`) and `service.py` (`RAGService` class). The contract is intentionally narrower than `/api/retrieve`: clients pass only **semantic** parameters (`query`, `top_k≤20`, `language`, `forbidden_works`); pipeline knobs (`rerank`, `expand_parents`, collection, per-channel limit) are **server-side defaults** read from `Settings`. Response strips internal diagnostics (`rrf_score`, `per_channel_rank`, `rerank_score`, `parent_chunk_id`, `chunk_id`) and exposes only `text` (parent), `snippet` (matched child), and a normalised `score ∈ [0,1]`. **Score normalisation:** sigmoid on rerank logits when reranker ran, RRF/top-RRF fallback otherwise — within-response only, not a calibrated probability. **`PipelineMetadata`** carries `version` (e.g. `dharma_v2-rerank0-parents1`), `collection`, `rerank`, `expand_parents`, `n_candidates` (pre-`forbidden_works` pool size). **Resource sharing:** `src/api/query.py::install_router` reuses the singleton `RetrievalResources` from `src.api.retrieve.get_resources()` — no second BGE-M3 (2.3 GB) or reranker (1.1 GB) load. Lifespan ordering enforces install of retrieve before query. Concept doc `docs/concepts/13-rag-service-contract.md`. **18 new unit tests** (schemas + service helpers + RAGService.query with stubbed `hybrid_search`); full suite 285 passed; mypy strict + ruff clean.

--- a/docs/RELEASE_v0.1.0.md
+++ b/docs/RELEASE_v0.1.0.md
@@ -1,0 +1,115 @@
+# v0.1.0 — Phase 1 Foundation
+
+End of the 21-day Phase 1 plan. Three previous releases (`v0.0.1`, `v0.0.2`, `v0.0.3`) shipped the corpus, chunker, embedder, and observability scaffold. **`v0.1.0` is the first release with a usable retrieval surface**: a stable `POST /api/query` endpoint that returns ranked Buddhist-canon passages with normalised scores, and an internal `POST /api/retrieve` for evaluation and tuning.
+
+LLM generation, citation verification, and the front-end are deliberately out of scope here — they're Phase 2+ (rag-day-22 onward) and the App-track that starts in parallel from app-day-01.
+
+---
+
+## Highlights
+
+- 🔍 **`POST /api/query` — stable production retrieval contract** (day 19). Accepts only semantic params (`query`, `top_k≤20`, `language`, `forbidden_works`); pipeline knobs are **server-side defaults** so we can keep tuning RRF weights, swap rerankers, and re-encode collections without breaking downstream consumers (LLM service, future Telegram bot, frontend). Response strips internal diagnostics and exposes only `Source(work_canonical_id, segment_id, text, snippet, score ∈ [0, 1])` + `PipelineMetadata(version, collection, rerank, expand_parents, n_candidates)`. Concept: [`13 — RAG-service contract`](concepts/13-rag-service-contract.md).
+- 🧭 **Hybrid retrieval — RRF over 3 channels** (day 12). Dense BGE-M3 + sparse BGE-M3 + Postgres BM25 (`tsvector` GIN, ASCII-folded for Pāli diacritic-insensitive matching), fused via Reciprocal Rank Fusion (k=60). One async pipeline; ~80 ms end-to-end on GPU.
+- 🪜 **Contextual Retrieval (Anthropic pattern), `dharma_v2`** (days 15-17). Each child chunk gets a 50-100 token LLM-generated *context prefix* (sutta name, section, immediate context) prepended before BGE-M3 encoding. Industrial run via OpenRouter (Anthropic Haiku 3.5) on 6,478 children, ~$8 total. Synthetic-golden A/B: `ref_hit@5` rose **0.400 → 0.567** (+16.7 pp); `MRR` rose 0.244 → 0.368. Concept: [`11 — Contextual Retrieval`](concepts/11-contextual-retrieval.md).
+- 🪟 **Small-to-big retrieval** (day 18). Search children (~384 tokens, precise), return parents (~1024-2048 tokens, rich context). One self-JOIN in Postgres; LLM gets a semantically-complete passage, UI gets the precise child fragment for highlighting (`snippet` field). Concept: [`12 — Parent/child retrieval`](concepts/12-parent-child-retrieval.md).
+- ⚡ **Production-default flipped** (day 18 cutover, after the day-17 A/B). `dharma_v2` + `rerank=False` + `expand_parents=True`. The cross-encoder reranker **degrades** quality on context-prefixed embeddings (v2+rerank 0.467 < v2 alone 0.567) — likely because BGE-reranker-v2-m3 was trained on raw chunk text. The reranker stays optional via `rerank: bool | None` in `/api/retrieve` for A/B; production never pays its 7-20 s/query cost.
+- 📊 **Eval framework** (day 14, extended day 17). `src/eval/` with typed YAML golden loader, pure-function metrics (`ref_hit@K`, MRR), and a runner that A/B's any two configurations. Synthetic v0.0 (30 QA, generated against the live corpus) is the iteration set; B-001 (authoritative buddhologist v0.1) is still open. Reports in [`docs/EVAL_BASELINE.md`](EVAL_BASELINE.md) and [`docs/EVAL_CONTEXTUAL_AB.md`](EVAL_CONTEXTUAL_AB.md).
+- 📚 **Integration-level documentation** (day 20). [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) — module map, ingest + query data flow, storage, deps, dependency rules. [`docs/RAG_PIPELINE.md`](RAG_PIPELINE.md) — runtime trace of one `POST /api/query`: mermaid sequence + component diagrams, per-stage Phoenix spans, latency breakdown, failure modes. Sits above the 13 per-concept docs in [`docs/concepts/`](concepts/INDEX.md).
+- 🔭 **Phoenix per-stage spans**. Every retrieval request emits `hybrid.encode`, `hybrid.channels`, `hybrid.rrf`, `hybrid.enrich`, and (when active) `hybrid.rerank` under the FastAPI request span — visible end-to-end at `localhost:6006`.
+
+## Numbers (synthetic golden v0.0, n=30)
+
+| Configuration | `ref_hit@5` | `ref_hit@20` | `MRR` | Latency/query |
+|---|---:|---:|---:|---:|
+| `dharma_v1` + rerank (day-13 baseline) | 0.400 | 0.600 | 0.244 | ~7.5 s |
+| `dharma_v1` + no rerank | 0.367 | 0.533 | 0.246 | ~95 ms |
+| `dharma_v2` + rerank | 0.467 | 0.733 | 0.319 | ~7.5 s |
+| **`dharma_v2` + no rerank (production)** | **0.567** | **0.767** | **0.368** | **~80 ms** |
+
+Synthetic v0.0 is **directional**, not authoritative. It was bootstrapped from the live corpus to unblock iteration while waiting for the buddhologist-built v0.1 (blocker B-001). Quality verdicts at v1.0 and beyond will require human-annotated ground truth.
+
+## What's not in this release
+
+- **No LLM generation.** `POST /api/query` returns ranked sources only — citation-aware generation, prompt caching, hallucination guards live in Phase 2 (rag-day-22+).
+- **No frontend.** App-track (Next.js + Telegram bot + audit log) starts in parallel from app-day-01 and consumes the v0.1.0 `POST /api/query` contract.
+- **No CI.** Pre-commit hooks (ruff + ruff-format + mypy strict + detect-secrets + line-ending) keep the local safety net intact. CI re-introduction tracked as **B-004** with `uv` (Astral) before broader release.
+- **No buddhologist golden set.** Iteration runs on synthetic v0.0 (30 QA). Full quality claims wait for B-001.
+
+## Stats
+
+- **285 unit tests passing** (~3 s, hermetic, no GPU/Qdrant/Postgres needed). Pre-commit gating on ruff, mypy, detect-secrets.
+- **6,478 child chunks** in `dharma_v2` (with Contextual Retrieval prefix), encoded by BGE-M3 fp16 on GTX 1080 Ti.
+- **~80 ms** end-to-end per query on warm GPU.
+- **4 Alembic migrations** (FRBR + author seeds + `chunk.fts_vector` + `chunk.context_text/version/model`).
+- **13 concept docs** + 2 integration docs + 1 ADR — all in [`docs/`](.).
+
+## Quickstart
+
+```bash
+git clone https://github.com/toneruseman/Dharma-RAG.git
+cd Dharma-RAG
+python -m venv .venv && source .venv/bin/activate  # or .venv\Scripts\activate on Windows
+pip install -e ".[dev]"
+cp .env.example .env
+
+# Bring up Postgres + Qdrant + Phoenix
+docker compose up -d
+alembic upgrade head
+
+# Load corpus (one-time, ~10 min)
+git clone --depth 1 --branch published \
+  https://github.com/suttacentral/bilara-data.git data/raw/suttacentral
+python scripts/ingest_sc.py --nikayas mn,dn,sn,an
+python scripts/rechunk.py
+
+# Index dharma_v2 (Contextual Retrieval). Needs OPENROUTER_API_KEY.
+# ~110 min wallclock @ concurrency=5, ~$8 via Anthropic Haiku 3.5.
+python scripts/contextualize_corpus.py
+python scripts/reindex_qdrant_v2.py
+
+# Run the API
+uvicorn src.api.app:app --reload
+
+# Try it
+curl -X POST http://localhost:8000/api/query \
+  -H "Content-Type: application/json" \
+  -d '{"query": "what is dukkha?", "top_k": 5}'
+```
+
+Phoenix UI at `http://localhost:6006` — full request span tree on every call.
+
+## Migration from v0.0.3
+
+1. Pull `dev`, run `alembic upgrade head` (migrations 003 + 004 introduce FTS + contextual columns).
+2. **Reindex Qdrant** to populate `dharma_v2`:
+   ```bash
+   python scripts/contextualize_corpus.py
+   python scripts/reindex_qdrant_v2.py
+   ```
+   `dharma_v1` (raw text) stays in place — the day-17 A/B and any rollback path still need it.
+3. **Replace any prior client of `POST /api/retrieve`** (if you wired one before this release) with `POST /api/query`. The old endpoint stays available for evaluation, but its surface will keep evolving with retrieval-engine changes.
+4. Set `OPENROUTER_API_KEY` in `.env` if you want to re-run Contextual Retrieval (otherwise `dharma_v2` Postgres columns are read-only and Qdrant collection is enough).
+
+## Open blockers
+
+- **B-001:** authoritative golden v0.1 from a buddhologist. Synthetic v0.0 unblocks iteration but is not authoritative for quality claims at v1.0.
+- **B-004:** CI re-introduction with `uv` before broader release.
+
+Both tracked in [`docs/STATUS.md`](STATUS.md).
+
+## What ships next
+
+- **Phase 2 (rag-day-22+):** LLM generation on top of `POST /api/query`. Citation verification, hallucination guards, prompt caching. Quality loop: golden set expansion, fine-tuning evals, Pāli glossary integration.
+- **App-track (app-day-01+):** Next.js + Tailwind UI, Docker Compose dev stack, audit logging, refused-query log. Integration through the frozen `src/rag/schemas.py`.
+- **Phase 3+:** Whisper transcription of dharmaseed talks (corpus expansion), voice interface (LiveKit + Deepgram + ElevenLabs).
+
+Authoritative roadmap: [`docs/RAG_DEVELOPMENT_PLAN.md`](RAG_DEVELOPMENT_PLAN.md), [`docs/APP_DEVELOPMENT_PLAN.md`](APP_DEVELOPMENT_PLAN.md). Day-by-day status: [`docs/STATUS.md`](STATUS.md).
+
+---
+
+Tag this release after merging the bump PR:
+
+```bash
+git tag -a v0.1.0 -m "v0.1.0 — Phase 1 Foundation"
+git push origin v0.1.0
+```

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -6,9 +6,9 @@
 > **Source of truth:** git log + этот файл. Чаты не являются source of truth.
 
 - **Версия:** 2026-04-28
-- **Ветка:** `dev` (активная: `feat/rag-day-20-docs`)
-- **Последний релиз:** `v0.0.3` — Retrieval Foundation (2026-04-22)
-- **Следующий milestone:** v0.1.0 Foundation (rag-day-21)
+- **Ветка:** `dev` (активная: `feat/rag-day-21-v0.1.0-release`)
+- **Последний релиз:** `v0.1.0` — Phase 1 Foundation (2026-04-28)
+- **Следующий milestone:** v0.2.0 (Phase 2 — LLM generation, rag-day-22+)
 - **Стратегия:** **B** — RAG-first до `v0.1.0` (`rag-day-21`), затем интерливинг RAG+APP
 
 ---
@@ -51,7 +51,8 @@
 | rag-day-17 | A/B `dharma_v1` vs `dharma_v2` on synthetic golden v0.0. **Headline win**: `ref_hit@5` 0.400 → 0.567 (+16.7 pp), `ref_hit@20` 0.600 → 0.767 (+16.7 pp), MRR 0.244 → 0.368 (+12.4 pp). **Surprise**: cross-encoder reranker **degrades** quality on contextualized embeddings (v2+rerank 0.467 < v2 alone 0.567). New production-default candidate: **`dharma_v2` + `rerank=False`** (~115× faster per query). Day-14 headline miss (qa_002 sn56.11) FIXED — sutta now at top-5. `docs/EVAL_CONTEXTUAL_AB.md` published. 269 unit tests. | ✅ Done | `7fd3a7e` |
 | rag-day-18 | Parent/child small-to-big retrieval + production cutover. New `HybridHit.child_text/expanded` fields; `_enrich` does a self-JOIN to substitute parent text when present. `hybrid_search(expand_parents=True)` default; reranker still scores `child_text` (independent of expansion). Production cutover: `RetrievalResources` now reads `settings.retrieval_collection` (`dharma_v2`), `retrieval_rerank_default` (False), `retrieval_expand_parents_default` (True). Concept doc 12. 267 unit tests. | ✅ Done | `de85fea` |
 | rag-day-19 | `POST /api/query` — stable production retrieval endpoint with frozen contract. New `src/rag/{schemas,service}.py`: `QueryRequest` (semantic params only — no `rerank`/`expand_parents` knobs), `QueryResponse` with stripped `Source` shape (no internal scores/IDs), `PipelineMetadata` (`version`, `collection`, `rerank`, `expand_parents`, `n_candidates`). `RAGService` reuses `RetrievalResources` singleton via `get_resources()` — no second BGE-M3 load. Score normalisation: sigmoid on rerank, RRF/top-RRF otherwise. `forbidden_works` post-filter. Concept doc 13. 285 unit tests. | ✅ Done | `72d4dba` |
-| rag-day-20 | Integration-level docs: `docs/ARCHITECTURE.md` (module map, data flow ingest→query, storage, external deps, dependency rules) + `docs/RAG_PIPELINE.md` (per-stage runtime trace, mermaid sequence + component diagrams, Phoenix span tree, latency breakdown ~78 ms, failure modes table). Sits above per-concept docs in `docs/concepts/` as the "single page that explains the whole system". No code changes; 285 unit tests still green. | ✅ Done | (this branch) |
+| rag-day-20 | Integration-level docs: `docs/ARCHITECTURE.md` (module map, data flow ingest→query, storage, external deps, dependency rules) + `docs/RAG_PIPELINE.md` (per-stage runtime trace, mermaid sequence + component diagrams, Phoenix span tree, latency breakdown ~78 ms, failure modes table). Sits above per-concept docs in `docs/concepts/` as the "single page that explains the whole system". No code changes; 285 unit tests still green. | ✅ Done | `8406793` |
+| **rag-day-21** | **`v0.1.0` release — Phase 1 Foundation closed.** Version bumped 0.0.3 → 0.1.0 in `src/__init__.py` + `pyproject.toml`. CHANGELOG `[Unreleased]` consolidated under `[0.1.0] — 2026-04-28`. `docs/RELEASE_v0.1.0.md` published (highlights, numbers, what's not in scope, quickstart, migration from v0.0.3, blockers, what ships next). 285 unit tests green; mypy strict + ruff clean. Tag `v0.1.0` to be created after PR merge. | ✅ Done | (this branch) |
 | … | (всего 120 дней в плане) | | |
 
 ### App-трек

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dharma-rag"
-version = "0.0.3"
+version = "0.1.0"
 description = "Open-source multilingual RAG for Buddhist contemplative teachings"
 readme = "README.md"
 license = "MIT"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """Dharma RAG — Open-source multilingual RAG for Buddhist contemplative teachings."""
 
-__version__ = "0.0.3"
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary

- Closes the 21-day Phase 1 plan. Version bumped 0.0.3 → 0.1.0 in [`src/__init__.py`](src/__init__.py) and [`pyproject.toml`](pyproject.toml).
- CHANGELOG `[Unreleased]` block consolidated under `## [0.1.0] — 2026-04-28 — Phase 1 Foundation` with a release-summary header (production config, headline numbers, latency, gate result).
- New [`docs/RELEASE_v0.1.0.md`](docs/RELEASE_v0.1.0.md) — authoritative release-notes artefact (highlights, numbers, what's not in scope, stats, quickstart, migration from v0.0.3, blockers, what ships next).
- [`docs/STATUS.md`](docs/STATUS.md) — last-release line, milestone arrow → v0.2.0, day-21 row.

## Surface delivered in v0.1.0

* `POST /api/query` — frozen public retrieval contract (day 19)
* `POST /api/retrieve` — internal diagnostic surface
* `/health`
* hybrid retrieval: BGE-M3 dense + sparse + Postgres BM25, RRF fusion, optional cross-encoder rerank
* Contextual Retrieval (`dharma_v2`) production-default
* parent/child small-to-big expansion
* Phoenix per-stage spans

## Numbers (synthetic golden v0.0, n=30 — directional, B-001 open)

| Configuration | ref_hit@5 | ref_hit@20 | MRR | Latency/query |
|---|---:|---:|---:|---:|
| `dharma_v1` + rerank (day-13 baseline) | 0.400 | 0.600 | 0.244 | ~7.5 s |
| `dharma_v1` + no rerank | 0.367 | 0.533 | 0.246 | ~95 ms |
| `dharma_v2` + rerank | 0.467 | 0.733 | 0.319 | ~7.5 s |
| **`dharma_v2` + no rerank (production)** | **0.567** | **0.767** | **0.368** | **~80 ms** |

## Out of scope (deliberate)

LLM generation (→ Phase 2, rag-day-22+), frontend (→ App-track), CI (→ B-004 with `uv` pre-broader-release), buddhologist golden set (→ B-001).

## Test plan
- [x] 285 unit tests green
- [x] `import src; src.__version__ == "0.1.0"`
- [x] Pre-commit gates pass (ruff, ruff-format, mypy strict, detect-secrets, mixed-line-ending)
- [ ] After merge: `git tag -a v0.1.0` + `git push origin v0.1.0`
- [ ] Optional: `gh release create v0.1.0` with `RELEASE_v0.1.0.md` body

🤖 Generated with [Claude Code](https://claude.com/claude-code)